### PR TITLE
Add missing test dependencies to setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.cache
+.pytest_cache
+dist
+**/*.egg-info
+**/__pycache__
+venv

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
 
     install_requires=[],
-    extra_require={
-        'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock']
+    extras_require={
+        'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'Flask', 'boto3']
     },
 )


### PR DESCRIPTION
The unit tests depend on the Flask and boto3 pip packages.

After adding these, I was able to successfully run in a new virtualenv:

python setup.py sdist
pip install dist/sagemaker_container_support-1.0.tar.gz[test]
pytest test
