### PR TITLE
Copy in change from internal repo: support pip install requirements.txt

### DIFF
--- a/src/container_support/serving.py
+++ b/src/container_support/serving.py
@@ -37,10 +37,14 @@ class Server(object):
         cs.configure_logging()
         logger.info("creating Server instance")
         env = cs.HostingEnvironment()
+
+        env.pip_install_requirements()
         logger.info("importing user module")
         user_module = env.import_user_module() if env.user_script_name else None
+
         framework = cs.ContainerEnvironment.load_framework()
         transformer = framework.transformer(user_module)
+
         server = Server("model server", transformer)
         logger.info("returning initialized server")
         return server


### PR DESCRIPTION
This change allows users to specify a pip requirements file to be installed on startup in the container.
See change in internal repo for additional context. This is a pure copy/paste.

tests succeeded after change:

python setup.py sdist
pip install --upgrade "dist/sagemaker_container_support-1.0.tar.gz[test]"
pytest test