### PR TITLE
Read new TRAINING_JOB_NAME environment variable during training

### DIFF
--- a/src/container_support/environment.py
+++ b/src/container_support/environment.py
@@ -1,14 +1,14 @@
 #  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#  
+#
 #  Licensed under the Apache License, Version 2.0 (the "License").
 #  You may not use this file except in compliance with the License.
 #  A copy of the License is located at
-#  
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-#  
-#  or in the "license" file accompanying this file. This file is distributed 
-#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-#  express or implied. See the License for the specific language governing 
+#
+#  or in the "license" file accompanying this file. This file is distributed
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
 import importlib
@@ -159,6 +159,7 @@ class TrainingEnvironment(ContainerEnvironment):
     RESOURCE_CONFIG_FILE = "resourceconfig.json"
     INPUT_DATA_CONFIG_FILE = "inputdataconfig.json"
     S3_URI_PARAM = 'sagemaker_s3_uri'
+    TRAINING_JOB_ENV = 'training_job_name'
 
     def __init__(self, base_dir=ContainerEnvironment.BASE_DIRECTORY):
         super(TrainingEnvironment, self).__init__(base_dir)
@@ -190,6 +191,9 @@ class TrainingEnvironment(ContainerEnvironment):
             "data",
             self.current_host if len(self.hosts) > 1 else '')
         "The dir to write non-model training artifacts (e.g. evaluation results) which will be retained by SageMaker. "
+
+        self.training_job_name = os.environ.get(TrainingEnvironment.TRAINING_JOB_ENV.upper(), None)
+        "The name of the current training job"
 
         # TODO validate docstring
         self.channels = self._load_config(

--- a/src/container_support/environment.py
+++ b/src/container_support/environment.py
@@ -192,7 +192,7 @@ class TrainingEnvironment(ContainerEnvironment):
             self.current_host if len(self.hosts) > 1 else '')
         "The dir to write non-model training artifacts (e.g. evaluation results) which will be retained by SageMaker. "
 
-        self.training_job_name = os.environ.get(TrainingEnvironment.TRAINING_JOB_ENV.upper(), None)
+        self.job_name = os.environ.get(TrainingEnvironment.TRAINING_JOB_ENV.upper(), None)
         "The name of the current training job"
 
         # TODO validate docstring

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -1,14 +1,14 @@
 #  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#  
+#
 #  Licensed under the Apache License, Version 2.0 (the "License").
 #  You may not use this file except in compliance with the License.
 #  A copy of the License is located at
-#  
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-#  
-#  or in the "license" file accompanying this file. This file is distributed 
-#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-#  express or implied. See the License for the specific language governing 
+#
+#  or in the "license" file accompanying this file. This file is distributed
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
 import json
@@ -61,6 +61,7 @@ def hosting():
 
 @pytest.fixture()
 def training():
+    os.environ[TrainingEnvironment.TRAINING_JOB_ENV.upper()] = 'training_job_name'
 
     d = optml(['input/data/training', 'input/config', 'model', 'output/data'])
 
@@ -231,6 +232,11 @@ def test_user_script_name_training(training):
 def test_user_requirements_file_training(training):
     env = TrainingEnvironment(training)
     assert env.user_requirements_file == 'requirements.txt'
+
+
+def test_training_job_name(training):
+    env = TrainingEnvironment(training)
+    assert env.training_job_name == 'training_job_name'
 
 
 @patch('tempfile.gettempdir')

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -236,7 +236,7 @@ def test_user_requirements_file_training(training):
 
 def test_training_job_name(training):
     env = TrainingEnvironment(training)
-    assert env.training_job_name == 'training_job_name'
+    assert env.job_name == 'training_job_name'
 
 
 @patch('tempfile.gettempdir')


### PR DESCRIPTION
*Description of changes:*
This change saves the new training environment variable that is saved by SageMaker so that it can be used by future containers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
