### PR TITLE
Split Environment class into Training/Serving

### DIFF
--- a/src/sagemaker_containers/__init__.py
+++ b/src/sagemaker_containers/__init__.py
@@ -12,5 +12,4 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-from sagemaker_containers import collections, modules  # noqa ignore=F401 imported but unused
-from sagemaker_containers.environment import Environment  # noqa ignore=F401 imported but unused
+from sagemaker_containers import collections, modules, environment  # noqa ignore=F401 imported but unused

--- a/src/sagemaker_containers/__init__.py
+++ b/src/sagemaker_containers/__init__.py
@@ -13,3 +13,5 @@
 from __future__ import absolute_import
 
 from sagemaker_containers import collections, modules, environment  # noqa ignore=F401 imported but unused
+from sagemaker_containers.environment import Environment, ServingEnvironment, TrainingEnvironment  # noqa ignore=F401
+#  imported but unused

--- a/src/sagemaker_containers/environment.py
+++ b/src/sagemaker_containers/environment.py
@@ -255,9 +255,6 @@ class Environment(collections.Mapping):
         enable_metrics = util.strtobool(os.environ.get(ENABLE_METRICS_ENV, 'false')) == 1
         log_level = os.environ.get(LOG_LEVEL_ENV, logging.INFO)
 
-        sagemaker_region = os.environ.get(REGION_NAME_ENV, session.region_name)
-        os.environ[REGION_NAME_ENV] = sagemaker_region
-
         self._current_host = current_host
         self._num_gpu = gpu_count()
         self._num_cpu = cpu_count()

--- a/src/sagemaker_containers/environment.py
+++ b/src/sagemaker_containers/environment.py
@@ -665,7 +665,7 @@ class ServingEnvironment(Environment):
     @property
     def use_nginx(self):  # type: () -> bool
         """Returns:
-            (bool): whether to use nginx as a reverse proxy"""
+            (bool): whether to use nginx as a reverse proxy. Default: True"""
         return self._use_nginx
 
     @property

--- a/src/sagemaker_containers/environment.py
+++ b/src/sagemaker_containers/environment.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import
 
 import collections
+import distutils
 import json
 import logging
 import multiprocessing
@@ -251,7 +252,7 @@ class Environment(collections.Mapping):
         current_host = os.environ.get(CURRENT_HOST_ENV)
         module_name = os.environ.get(USER_PROGRAM_ENV, None)
         module_dir = os.environ.get(SUBMIT_DIR_ENV, None)
-        enable_metrics = os.environ.get(ENABLE_METRICS_ENV, 'false') == 'true'
+        enable_metrics = distutils.util.strtobool(os.environ.get(ENABLE_METRICS_ENV, 'false')) == 1
         log_level = os.environ.get(LOG_LEVEL_ENV, logging.INFO)
 
         sagemaker_region = os.environ.get(REGION_NAME_ENV, session.region_name)
@@ -653,7 +654,7 @@ class ServingEnvironment(Environment):
         """
         super(ServingEnvironment, self).__init__(session)
 
-        use_nginx = os.environ.get(USE_NGINX_ENV, 'true') == 'true'
+        use_nginx = distutils.util.strtobool(os.environ.get(USE_NGINX_ENV, 'true')) == 1
         model_server_timeout = int(os.environ.get(MODEL_SERVER_TIMEOUT_ENV, '60'))
         model_server_workers = int(os.environ.get(MODEL_SERVER_WORKERS_ENV, cpu_count()))
 
@@ -670,7 +671,8 @@ class ServingEnvironment(Environment):
     @property
     def model_server_timeout(self):  # type: () -> int
         """Returns:
-            (int): Timeout in seconds for the model server."""
+            (int): Timeout in seconds for the model server. This is passed over to gunicorn, from the docs:
+                Workers silent for more than this many seconds are killed and restarted. Our default value is 60."""
         return self._model_server_timeout
 
     @property

--- a/src/sagemaker_containers/environment.py
+++ b/src/sagemaker_containers/environment.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-from abc import ABCMeta, abstractmethod
 import collections
 import json
 import logging
@@ -24,7 +23,6 @@ import sys
 
 import boto3
 import six
-from six import with_metaclass
 
 import sagemaker_containers as smc
 
@@ -53,20 +51,30 @@ RESOURCE_CONFIG_FILE = 'resourceconfig.json'  # type: str
 INPUT_DATA_CONFIG_FILE = 'inputdataconfig.json'  # type: str
 
 USER_PROGRAM_PARAM = 'sagemaker_program'  # type: str
+USER_PROGRAM_ENV = USER_PROGRAM_PARAM.upper()  # type: str
+
 SUBMIT_DIR_PARAM = 'sagemaker_submit_directory'  # type: str
+SUBMIT_DIR_ENV = SUBMIT_DIR_PARAM.upper()  # type: str
+
 ENABLE_METRICS_PARAM = 'sagemaker_enable_cloudwatch_metrics'  # type: str
+ENABLE_METRICS_ENV = ENABLE_METRICS_PARAM.upper()  # type: str
+
 LOG_LEVEL_PARAM = 'sagemaker_container_log_level'  # type: str
+LOG_LEVEL_ENV = LOG_LEVEL_PARAM.upper()  # type: str
+
 JOB_NAME_PARAM = 'sagemaker_job_name'  # type: str
+JOB_NAME_ENV = JOB_NAME_PARAM.upper()  # type: str
+
 DEFAULT_MODULE_NAME_PARAM = 'default_user_module_name'  # type: str
-REGION_PARAM_NAME = 'sagemaker_region'  # type: str
+REGION_NAME_PARAM = 'sagemaker_region'  # type: str
+REGION_NAME_ENV = REGION_NAME_PARAM.upper()  # type: str
 
-SAGEMAKER_HYPERPARAMETERS = (USER_PROGRAM_PARAM, SUBMIT_DIR_PARAM, ENABLE_METRICS_PARAM, REGION_PARAM_NAME,
-                             LOG_LEVEL_PARAM, JOB_NAME_PARAM, DEFAULT_MODULE_NAME_PARAM)  # type: set
-
-# Serving
 MODEL_SERVER_WORKERS_ENV = 'SAGEMAKER_MODEL_SERVER_WORKERS'  # type: str
 MODEL_SERVER_TIMEOUT_ENV = 'SAGEMAKER_MODEL_SERVER_TIMEOUT'  # type: str
 USE_NGINX_ENV = 'SAGEMAKER_USE_NGINX'  # type: str
+
+SAGEMAKER_HYPERPARAMETERS = (USER_PROGRAM_PARAM, SUBMIT_DIR_PARAM, ENABLE_METRICS_PARAM, REGION_NAME_PARAM,
+                             LOG_LEVEL_PARAM, JOB_NAME_PARAM, DEFAULT_MODULE_NAME_PARAM)  # type: set
 
 
 def read_json(path):  # type: (str) -> dict
@@ -193,14 +201,20 @@ def cpu_count():  # type: () -> int
     return multiprocessing.cpu_count()
 
 
-class Environment(with_metaclass(ABCMeta, collections.Mapping)):
+class Environment(collections.Mapping):
     """Base Class which provides access to aspects of the environment including
     system characteristics, filesystem locations, environment variables and configuration settings.
 
     The environment is a read-only snapshot of the container environment. It does not contain any form of state.
     It is a dictionary like object, allowing any builtin function that works with dictionary.
-    """
 
+    Attributes:
+            current_host (str): The name of the current container on the container network. For example, 'algo-1'.
+            num_gpu (int): The number of gpus available in the current container.
+            num_cpu (int): The number of cpus available in the current container.
+            module_name (str): The name of the user provided module.
+            module_dir (str): The full path location of the user provided module.
+    """
     def properties(self):  # type: () -> list
         """
         Returns:
@@ -226,27 +240,27 @@ class Environment(with_metaclass(ABCMeta, collections.Mapping)):
         items = {_property: getattr(self, _property) for _property in self.properties()}
         return iter(items)
 
-    def __init__(self,
-                 current_host,  # type: str
-                 num_gpu,  # type: int
-                 num_cpu,  # type: int
-                 module_name,  # type: str
-                 module_dir,  # type: str
-                 enable_metrics,  # type: bool
-                 log_level  # type: int
-                 ):
+    def __init__(self, session=None):
+
         """
         Args:
-            current_host (str): The name of the current container on the container network. For example, 'algo-1'.
-
-            num_gpu (int): The number of gpus available in the current container.
-
-            num_cpu (int): The number of cpus available in the current container.
+            session (boto3.Session): an optional boto session to use if required.
         """
+        session = session or boto3.Session()
+
+        current_host = os.environ.get(CURRENT_HOST_ENV)
+        module_name = os.environ.get(USER_PROGRAM_ENV, None)
+        module_dir = os.environ.get(SUBMIT_DIR_ENV, None)
+        enable_metrics = os.environ.get(ENABLE_METRICS_ENV, 'false') == 'true'
+        log_level = os.environ.get(LOG_LEVEL_ENV, logging.INFO)
+
+        sagemaker_region = os.environ.get(REGION_NAME_ENV, session.region_name)
+        os.environ[REGION_NAME_ENV] = sagemaker_region
+
         self._current_host = current_host
-        self._num_gpu = num_gpu
-        self._num_cpu = num_cpu
-        self._module_name = self._parse_module_name(module_name)
+        self._num_gpu = gpu_count()
+        self._num_cpu = cpu_count()
+        self._module_name = module_name
         self._module_dir = module_dir
         self._enable_metrics = enable_metrics
         self._log_level = log_level
@@ -284,7 +298,7 @@ class Environment(with_metaclass(ABCMeta, collections.Mapping)):
         Returns:
             (str): name of the user provided module
         """
-        return self._module_name
+        return self._parse_module_name(self._module_name)
 
     @property
     def module_dir(self):  # type: () -> str
@@ -313,14 +327,6 @@ class Environment(with_metaclass(ABCMeta, collections.Mapping)):
         """
         return self._log_level
 
-    @classmethod
-    @abstractmethod
-    def create(cls, session=None):  # type: (boto3.Session) -> Environment
-        """
-        Returns: an instance of `Environment`
-        """
-        pass
-
     @staticmethod
     def _parse_module_name(program_param):
         """Given a module name or a script name, Returns the module name.
@@ -333,173 +339,158 @@ class Environment(with_metaclass(ABCMeta, collections.Mapping)):
         Returns:
             (str): Module name
         """
-        if program_param.endswith('.py'):
+        if program_param and program_param.endswith('.py'):
             return program_param[:-3]
         return program_param
 
 
 class TrainingEnvironment(Environment):
     """Provides access to aspects of the training environment relevant to training jobs, including
-       hyperparameters, system characteristics, filesystem locations, environment variables and configuration settings.
+    hyperparameters, system characteristics, filesystem locations, environment variables and configuration settings.
 
-       The environment is a read-only snapshot of the container environment. It does not contain any form of state.
-       It is a dictionary like object, allowing any builtin function that works with dictionary.
+    The environment is a read-only snapshot of the container environment. It does not contain any form of state.
+    It is a dictionary like object, allowing any builtin function that works with dictionary.
 
-       Example on how to print the state of the container:
-           >>> print(str(smc.environment.TrainingEnvironment.create()))
+    Example on how to print the state of the container:
+        >>> print(str(smc.environment.TrainingEnvironment.create()))
 
-       Example on how a script can use training environment:
-           ```
-           >>>import sagemaker_containers as smc
-           >>>env = smc.environment.TrainingEnvironment.create()
+    Example on how a script can use training environment:
+        ```
+            >>>import sagemaker_containers as smc
+            >>>env = smc.environment.TrainingEnvironment.create()
 
-           get the path of the channel 'training' from the inputdataconfig.json file
-           >>>training_dir = env.channel_input_dirs['training']
+            get the path of the channel 'training' from the inputdataconfig.json file
+            >>>training_dir = env.channel_input_dirs['training']
 
-           get a the hyperparameter 'training_data_file' from hyperparameters.json file
-           >>>file_name = env.hyperparameters['training_data_file']
+            get a the hyperparameter 'training_data_file' from hyperparameters.json file
+            >>>file_name = env.hyperparameters['training_data_file']
 
-           # get the folder where the model should be saved
-           >>>model_dir = env.model_dir
+            get the folder where the model should be saved
+            >>>model_dir = env.model_dir
+            >>>data = np.load(os.path.join(training_dir, training_data_file))
+            >>>x_train, y_train = data['features'], keras.utils.to_categorical(data['labels'])
+            >>>model = ResNet50(weights='imagenet')
+            ...
+            >>>model.fit(x_train, y_train)
 
-           >>>data = np.load(os.path.join(training_dir, training_data_file))
+            save the model in the end of training
+            >>>model.save(os.path.join(model_dir, 'saved_model'))
+        ```
 
-           >>>x_train, y_train = data['features'], keras.utils.to_categorical(data['labels'])
+    Attributes:
+        input_dir (str): The input_dir, e.g. /opt/ml/input/, is the directory where SageMaker saves input data
+            and configuration files before and during training. The input data directory has the
+            following subdirectories: config (`input_config_dir`) and data (`input_data_dir`)
 
-           >>>model = ResNet50(weights='imagenet')
+        input_config_dir (str): The directory where standard SageMaker configuration files are located,
+            e.g. /opt/ml/input/config/.
 
-           ...
-           >>>model.fit(x_train, y_train)
+            SageMaker training creates the following files in this folder when training starts:
+                - `hyperparameters.json`: Amazon SageMaker makes the hyperparameters in a CreateTrainingJob
+                        request available in this file.
+                - `inputdataconfig.json`: You specify data channel information in the InputDataConfig
+                        parameter in a CreateTrainingJob request. Amazon SageMaker makes this information
+                        available in this file.
+                - `resourceconfig.json`: name of the current host and all host containers in the training
 
-           save the model in the end of training
-           >>>model.save(os.path.join(model_dir, 'saved_model'))
-           ```
-       """
-    def __init__(self,
-                 input_dir,  # type: str
-                 input_config_dir,  # type: str
-                 model_dir,  # type: str
-                 output_dir,  # type: str
-                 hyperparameters,  # type: dict
-                 resource_config,  # type: dict
-                 input_data_config,  # type: dict
-                 output_data_dir,  # type: str
-                 hosts,  # type: () -> list
-                 channel_input_dirs,  # type: dict
-                 current_host,  # type: str
-                 num_gpu,  # type: int
-                 num_cpu,  # type: int
-                 module_name,  # type: str
-                 module_dir,  # type: str
-                 enable_metrics,  # type: bool
-                 log_level  # type: int
-                 ):
+            More information about these files can be find here:
+                https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo.html
+
+        model_dir (str):  the directory where models should be saved, e.g., /opt/ml/model/
+
+        output_dir (str): The directory where training success/failure indications will be written, e.g.
+            /opt/ml/output. To save non-model artifacts check `output_data_dir`.
+
+        hyperparameters (dict[string, object]): An instance of `HyperParameters` containing the training job
+                                                hyperparameters.
+
+        resource_config (dict[string, object]): the contents from /opt/ml/input/config/resourceconfig.json.
+            It has the following keys:
+                - current_host: The name of the current container on the container network.
+                    For example, 'algo-1'.
+                -  hosts: The list of names of all containers on the container network,
+                    sorted lexicographically. For example, `['algo-1', 'algo-2', 'algo-3']`
+                    for a three-node cluster.
+
+        input_data_config (dict[string, object]): the contents from /opt/ml/input/config/inputdataconfig.json.
+            For example, suppose that you specify three data channels (train, evaluation, and
+            validation) in your request. This dictionary will contain:
+
+            {'train': {
+                'ContentType':  'trainingContentType',
+                'TrainingInputMode': 'File',
+                'S3DistributionType': 'FullyReplicated',
+                'RecordWrapperType': 'None'
+            },
+            'evaluation' : {
+                'ContentType': 'evalContentType',
+                'TrainingInputMode': 'File',
+                'S3DistributionType': 'FullyReplicated',
+                'RecordWrapperType': 'None'
+            },
+            'validation': {
+                'TrainingInputMode': 'File',
+                'S3DistributionType': 'FullyReplicated',
+                'RecordWrapperType': 'None'
+            }}
+
+            You can find more information about /opt/ml/input/config/inputdataconfig.json here:
+            https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo.html#your-algorithms-training-algo-running-container-inputdataconfig
+
+        output_data_dir (str): The dir to write non-model training artifacts (e.g. evaluation results) which will be
+            retained by SageMaker, e.g. /opt/ml/output/data. As your algorithm runs in a container, it generates
+            output including the status of the training job and model and output artifacts. Your algorithm should
+            write this information to the this directory.
+
+        hosts (list[str]): The list of names of all containers on the container network, sorted lexicographically.
+            For example, `['algo-1', 'algo-2', 'algo-3']` for a three-node cluster.
+
+        channel_input_dirs (dict[string, string]): containing the data channels and the directories where the
+            training data was saved. When you run training, you can partition your training data into different logical
+            'channels'. Depending on your problem, some common channel ideas are: 'train', 'test',
+            'evaluation' or 'images','labels'.
+
+            The format of channel_input_dir is as follows:
+                - `channel`(str) - the name of the channel defined in the input_data_config.
+                - `training data path`(str) - the path to the directory where the training data is
+                saved.
+    """
+    def __init__(self, session=None):
         """
-
-        Args:
-            input_dir (str): The input_dir, e.g. /opt/ml/input/, is the directory where SageMaker saves input data
-                        and configuration files before and during training. The input data directory has the
-                        following subdirectories: config (`input_config_dir`) and data (`input_data_dir`)
-
-            input_config_dir (str): The directory where standard SageMaker configuration files are located,
-                        e.g. /opt/ml/input/config/.
-
-                        SageMaker training creates the following files in this folder when training starts:
-                            - `hyperparameters.json`: Amazon SageMaker makes the hyperparameters in a CreateTrainingJob
-                                    request available in this file.
-                            - `inputdataconfig.json`: You specify data channel information in the InputDataConfig
-                                    parameter in a CreateTrainingJob request. Amazon SageMaker makes this information
-                                    available in this file.
-                            - `resourceconfig.json`: name of the current host and all host containers in the training
-
-                        More information about these files can be find here:
-                            https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo.html
-
-            model_dir (str):  the directory where models should be saved, e.g., /opt/ml/model/
-
-            output_dir (str): The directory where training success/failure indications will be written, e.g.
-                        /opt/ml/output. To save non-model artifacts check `output_data_dir`.
-
-            hyperparameters (dict[string, object]): An instance of `HyperParameters` containing the training job
-                                                    hyperparameters.
-
-            resource_config (dict[string, object]): the contents from /opt/ml/input/config/resourceconfig.json.
-                            It has the following keys:
-                                - current_host: The name of the current container on the container network.
-                                    For example, 'algo-1'.
-                                -  hosts: The list of names of all containers on the container network,
-                                    sorted lexicographically. For example, `['algo-1', 'algo-2', 'algo-3']`
-                                    for a three-node cluster.
-
-            input_data_config (dict[string, object]): the contents from /opt/ml/input/config/inputdataconfig.json.
-
-                                For example, suppose that you specify three data channels (train, evaluation, and
-                                validation) in your request. This dictionary will contain:
-
-                                {'train': {
-                                    'ContentType':  'trainingContentType',
-                                    'TrainingInputMode': 'File',
-                                    'S3DistributionType': 'FullyReplicated',
-                                    'RecordWrapperType': 'None'
-                                },
-                                'evaluation' : {
-                                    'ContentType': 'evalContentType',
-                                    'TrainingInputMode': 'File',
-                                    'S3DistributionType': 'FullyReplicated',
-                                    'RecordWrapperType': 'None'
-                                },
-                                'validation': {
-                                    'TrainingInputMode': 'File',
-                                    'S3DistributionType': 'FullyReplicated',
-                                    'RecordWrapperType': 'None'
-                                }}
-
-                                You can find more information about /opt/ml/input/config/inputdataconfig.json here:
-                                https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo.html#your-algorithms-training-algo-running-container-inputdataconfig
-
-            output_data_dir (str): The dir to write non-model training artifacts (e.g. evaluation results) which will be
-                        retained by SageMaker, e.g. /opt/ml/output/data.
-
-                        As your algorithm runs in a container, it generates output including the status of the
-                        training job and model and output artifacts. Your algorithm should write this information
-                        to the this directory.
-
-            hosts (list[str]): The list of names of all containers on the container network, sorted lexicographically.
-                    For example, `['algo-1', 'algo-2', 'algo-3']` for a three-node cluster.
-
-            channel_input_dirs (dict[string, string]): containing the data channels and the directories where the
-                            training data was saved.
-
-                            When you run training, you can partition your training data into different logical
-                            'channels'. Depending on your problem, some common channel ideas are: 'train', 'test',
-                             'evaluation' or 'images','labels'.
-
-                            The format of channel_input_dir is as follows:
-
-                                - `channel`(str) - the name of the channel defined in the input_data_config.
-                                - `training data path`(str) - the path to the directory where the training data is
-                                saved.
-
-            current_host (str): The name of the current container on the container network. For example, 'algo-1'.
-
-            num_gpu (int): The number of gpus available in the current container.
-
-            num_cpu (int): The number of cpus available in the current container.
+            Args:
+                session (boto3.Session): an optional boto session to use if required.
         """
-        super(TrainingEnvironment, self).__init__(current_host, num_gpu, num_cpu, module_name, module_dir,
-                                                  enable_metrics, log_level)
+        super(TrainingEnvironment, self).__init__(session)
+
+        resource_config = read_resource_config()
+        current_host = resource_config['current_host']
+        hosts = resource_config['hosts']
+        input_data_config = read_input_data_config()
+        hyperparameters = read_hyperparameters()
+        sagemaker_hyperparameters, hyperparameters = smc.collections.split_by_criteria(hyperparameters,
+                                                                                       SAGEMAKER_HYPERPARAMETERS)
+        sagemaker_region = sagemaker_hyperparameters.get(REGION_NAME_ENV, session.region_name)
+        os.environ[JOB_NAME_ENV] = sagemaker_hyperparameters[JOB_NAME_PARAM]
+        os.environ[CURRENT_HOST_ENV] = current_host
+        os.environ[REGION_NAME_ENV] = sagemaker_region
 
         self._hosts = hosts
-        self._input_dir = input_dir
-        self._input_config_dir = input_config_dir
-        self._model_dir = model_dir
-        self._output_dir = output_dir
+        self._input_dir = INPUT_PATH
+        self._input_config_dir = INPUT_CONFIG_PATH
+        self._model_dir = MODEL_PATH
+        self._output_dir = OUTPUT_PATH
         self._hyperparameters = hyperparameters
         self._resource_config = resource_config
         self._input_data_config = input_data_config
-        self._output_data_dir = output_data_dir
-        self._channel_input_dirs = channel_input_dirs
+        self._output_data_dir = OUTPUT_DATA_PATH
+        self._channel_input_dirs = {channel: channel_path(channel) for channel in input_data_config}
         self._current_host = current_host
+
+        # override base class attributes
+        self._module_name = str(sagemaker_hyperparameters.get(USER_PROGRAM_PARAM))
+        self._module_dir = str(sagemaker_hyperparameters.get(SUBMIT_DIR_PARAM))
+        self._enable_metrics = sagemaker_hyperparameters.get(ENABLE_METRICS_PARAM, False)
+        self._log_level = sagemaker_hyperparameters.get(LOG_LEVEL_PARAM, logging.INFO)
 
     @property
     def hosts(self):  # type: () -> list
@@ -633,48 +624,6 @@ class TrainingEnvironment(Environment):
         """
         return self._channel_input_dirs
 
-    @classmethod
-    def create(cls, session=None):  # type: (boto3.Session) -> Environment
-        """
-        Returns: an instance of `TrainingEnvironment`
-        """
-        session = session or boto3.Session()
-
-        resource_config = read_resource_config()
-        current_host = resource_config['current_host']
-        hosts = resource_config['hosts']
-
-        input_data_config = read_input_data_config()
-
-        hyperparameters = read_hyperparameters()
-        sagemaker_hyperparameters, hyperparameters = smc.collections.split_by_criteria(hyperparameters,
-                                                                                       SAGEMAKER_HYPERPARAMETERS)
-
-        sagemaker_region = sagemaker_hyperparameters.get(REGION_PARAM_NAME, session.region_name)
-
-        os.environ[JOB_NAME_ENV] = sagemaker_hyperparameters[JOB_NAME_PARAM]
-        os.environ[CURRENT_HOST_ENV] = current_host
-        os.environ[REGION_PARAM_NAME.upper()] = sagemaker_region
-
-        return cls(input_dir=INPUT_PATH,
-                   input_config_dir=INPUT_CONFIG_PATH,
-                   model_dir=MODEL_PATH,
-                   output_dir=OUTPUT_PATH,
-                   output_data_dir=OUTPUT_DATA_PATH,
-                   current_host=current_host,
-                   hosts=hosts,
-                   channel_input_dirs={channel: channel_path(channel) for channel in input_data_config},
-                   num_gpu=gpu_count(),
-                   num_cpu=cpu_count(),
-                   hyperparameters=hyperparameters,
-                   resource_config=resource_config,
-                   input_data_config=read_input_data_config(),
-                   module_name=str(sagemaker_hyperparameters.get(USER_PROGRAM_PARAM)),
-                   module_dir=str(sagemaker_hyperparameters.get(SUBMIT_DIR_PARAM)),
-                   enable_metrics=sagemaker_hyperparameters.get(ENABLE_METRICS_PARAM, False),
-                   log_level=sagemaker_hyperparameters.get(LOG_LEVEL_PARAM, logging.INFO)
-                   )
-
 
 class ServingEnvironment(Environment):
     """Provides access to aspects of the serving environment relevant to serving containers, including
@@ -691,39 +640,23 @@ class ServingEnvironment(Environment):
            >>>import sagemaker_containers as smc
            >>>env = smc.environment.ServingEnvironment.create()
 
-    """
-    def __init__(self,
-                 use_nginx,  # type: bool
-                 model_server_timeout,  # type: int
-                 model_server_workers,  # type: int
-                 hosts,  # type: () -> list
-                 current_host,  # type: str
-                 num_gpu,  # type: int
-                 num_cpu,  # type: int
-                 module_name,  # type: str
-                 module_dir,  # type: str
-                 enable_metrics,  # type: bool
-                 log_level,  # type: int
-                 ):
-        """
-        Args:
+
+        Attributes:
             use_nginx (bool): Whether to use nginx as a reverse proxy.
-
             model_server_timeout (int): Timeout in seconds for the model server.
-
             model_server_workers (int): Number of worker processes the model server will use.
-
-            hosts (list[str]): The list of names of all containers on the container network, sorted lexicographically.
-                    For example, `['algo-1', 'algo-2', 'algo-3']` for a three-node cluster.
-
-            current_host (str): The name of the current container on the container network. For example, 'algo-1'.
-
-            num_gpu (int): The number of gpus available in the current container.
-
-            num_cpu (int): The number of cpus available in the current container.:
+    """
+    def __init__(self, session=None):
         """
-        super(ServingEnvironment, self).__init__(current_host, num_gpu, num_cpu, module_name,
-                                                 module_dir, enable_metrics, log_level)
+            Args:
+                session (boto3.Session): an optional boto session to use if required.
+        """
+        super(ServingEnvironment, self).__init__(session)
+
+        use_nginx = os.environ.get(USE_NGINX_ENV, 'true') == 'true'
+        model_server_timeout = int(os.environ.get(MODEL_SERVER_TIMEOUT_ENV, '60'))
+        model_server_workers = int(os.environ.get(MODEL_SERVER_WORKERS_ENV, cpu_count()))
+
         self._use_nginx = use_nginx
         self._model_server_timeout = model_server_timeout
         self._model_server_workers = model_server_workers
@@ -745,26 +678,3 @@ class ServingEnvironment(Environment):
         """Returns:
             (int): Number of worker processes the model server will use"""
         return self._model_server_workers
-
-    @classmethod
-    def create(cls, session=None):  # type: (boto3.Session) -> Environment
-        """
-        Returns: an instance of `TrainingEnvironment`
-        """
-        session = session or boto3.Session()
-
-        use_nginx = os.environ.get(USE_NGINX_ENV, 'true') == 'true'
-        model_server_timeout = int(os.environ.get(MODEL_SERVER_TIMEOUT_ENV, '60'))
-        model_server_workers = int(os.environ.get(MODEL_SERVER_WORKERS_ENV, cpu_count()))
-        hosts = None
-        current_host = os.environ.get(CURRENT_HOST_ENV)
-        module_name = os.environ.get(USER_PROGRAM_PARAM.upper(), None)
-        module_dir = os.environ.get(SUBMIT_DIR_PARAM.upper(), None)
-        enable_metrics = os.environ.get(ENABLE_METRICS_PARAM.upper(), 'false') == 'true'
-        log_level = os.environ.get(LOG_LEVEL_PARAM.upper(), '')
-
-        sagemaker_region = os.environ.get(REGION_PARAM_NAME.upper(), session.region_name)
-        os.environ[REGION_PARAM_NAME.upper()] = sagemaker_region
-
-        return cls(use_nginx, model_server_timeout, model_server_workers, hosts, current_host,
-                   gpu_count(), cpu_count(), module_name, module_dir, enable_metrics, log_level)

--- a/src/sagemaker_containers/environment.py
+++ b/src/sagemaker_containers/environment.py
@@ -13,7 +13,7 @@
 from __future__ import absolute_import
 
 import collections
-import distutils
+from distutils import util
 import json
 import logging
 import multiprocessing
@@ -252,7 +252,7 @@ class Environment(collections.Mapping):
         current_host = os.environ.get(CURRENT_HOST_ENV)
         module_name = os.environ.get(USER_PROGRAM_ENV, None)
         module_dir = os.environ.get(SUBMIT_DIR_ENV, None)
-        enable_metrics = distutils.util.strtobool(os.environ.get(ENABLE_METRICS_ENV, 'false')) == 1
+        enable_metrics = util.strtobool(os.environ.get(ENABLE_METRICS_ENV, 'false')) == 1
         log_level = os.environ.get(LOG_LEVEL_ENV, logging.INFO)
 
         sagemaker_region = os.environ.get(REGION_NAME_ENV, session.region_name)
@@ -656,7 +656,7 @@ class ServingEnvironment(Environment):
         """
         super(ServingEnvironment, self).__init__(session)
 
-        use_nginx = distutils.util.strtobool(os.environ.get(USE_NGINX_ENV, 'true')) == 1
+        use_nginx = util.strtobool(os.environ.get(USE_NGINX_ENV, 'true')) == 1
         model_server_timeout = int(os.environ.get(MODEL_SERVER_TIMEOUT_ENV, '60'))
         model_server_workers = int(os.environ.get(MODEL_SERVER_WORKERS_ENV, cpu_count()))
 

--- a/src/sagemaker_containers/environment.py
+++ b/src/sagemaker_containers/environment.py
@@ -350,12 +350,12 @@ class TrainingEnvironment(Environment):
     It is a dictionary like object, allowing any builtin function that works with dictionary.
 
     Example on how to print the state of the container:
-        >>> print(str(smc.environment.TrainingEnvironment.create()))
+        >>> print(str(smc.environment.TrainingEnvironment()))
 
     Example on how a script can use training environment:
         ```
             >>>import sagemaker_containers as smc
-            >>>env = smc.environment.TrainingEnvironment.create()
+            >>>env = smc.environment.TrainingEnvironment()
 
             get the path of the channel 'training' from the inputdataconfig.json file
             >>>training_dir = env.channel_input_dirs['training']
@@ -469,7 +469,7 @@ class TrainingEnvironment(Environment):
         hyperparameters = read_hyperparameters()
         sagemaker_hyperparameters, hyperparameters = smc.collections.split_by_criteria(hyperparameters,
                                                                                        SAGEMAKER_HYPERPARAMETERS)
-        sagemaker_region = sagemaker_hyperparameters.get(REGION_NAME_ENV, session.region_name)
+        sagemaker_region = sagemaker_hyperparameters.get(REGION_NAME_PARAM, session.region_name)
         os.environ[JOB_NAME_ENV] = sagemaker_hyperparameters[JOB_NAME_PARAM]
         os.environ[CURRENT_HOST_ENV] = current_host
         os.environ[REGION_NAME_ENV] = sagemaker_region
@@ -633,12 +633,12 @@ class ServingEnvironment(Environment):
        It is a dictionary like object, allowing any builtin function that works with dictionary.
 
        Example on how to print the state of the container:
-           >>> print(str(smc.environment.ServingEnvironment.create()))
+           >>> print(str(smc.environment.ServingEnvironment()))
 
        Example on how a script can use training environment:
            ```
            >>>import sagemaker_containers as smc
-           >>>env = smc.environment.ServingEnvironment.create()
+           >>>env = smc.environment.ServingEnvironment()
 
 
         Attributes:

--- a/src/sagemaker_containers/environment.py
+++ b/src/sagemaker_containers/environment.py
@@ -463,6 +463,8 @@ class TrainingEnvironment(Environment):
         """
         super(TrainingEnvironment, self).__init__(session)
 
+        session = session or boto3.Session()
+
         resource_config = read_resource_config()
         current_host = resource_config['current_host']
         hosts = resource_config['hosts']

--- a/test/functional/test_keras_framework.py
+++ b/test/functional/test_keras_framework.py
@@ -56,7 +56,7 @@ def train(channel_input_dirs, hyperparameters):
 
 
 def keras_framework_training_fn():
-    env = smc.Environment.create()
+    env = smc.environment.TrainingEnvironment()
 
     mod = smc.modules.download_and_import(env.module_dir, env.module_name)
 

--- a/test/unit/test_environment.py
+++ b/test/unit/test_environment.py
@@ -13,6 +13,7 @@
 import itertools
 import json
 import logging
+import os
 
 from mock import Mock, patch
 import pytest
@@ -112,78 +113,104 @@ def test_cpu_count():
     assert smc.environment.cpu_count() == 2
 
 
-@pytest.fixture(name='environment')
-def create_environment():
+@pytest.fixture(name='training_environment')
+def create_trainin_environment():
     with patch('sagemaker_containers.environment.read_resource_config', lambda: RESOURCE_CONFIG), \
          patch('sagemaker_containers.environment.read_input_data_config', lambda: INPUT_DATA_CONFIG), \
          patch('sagemaker_containers.environment.read_hyperparameters', lambda: ALL_HYPERPARAMETERS), \
          patch('sagemaker_containers.environment.cpu_count', lambda: 8), \
          patch('sagemaker_containers.environment.gpu_count', lambda: 4):
-        return smc.Environment.create(session=Mock())
+        return smc.environment.TrainingEnvironment.create(session=Mock())
 
 
-def test_environment_create(environment):
-    assert environment.num_gpu == 4
-    assert environment.num_cpu == 8
-    assert environment.input_dir == '/opt/ml/input'
-    assert environment.input_config_dir == '/opt/ml/input/config'
-    assert environment.model_dir == '/opt/ml/model'
-    assert environment.output_dir == '/opt/ml/output'
-    assert environment.hyperparameters == USER_HYPERPARAMETERS
-    assert environment.resource_config == RESOURCE_CONFIG
-    assert environment.input_data_config == INPUT_DATA_CONFIG
-    assert environment.output_data_dir == '/opt/ml/output/data'
-    assert environment.hosts == RESOURCE_CONFIG['hosts']
-    assert environment.channel_input_dirs['train'] == '/opt/ml/input/data/train'
-    assert environment.channel_input_dirs['validation'] == '/opt/ml/input/data/validation'
-    assert environment.current_host == RESOURCE_CONFIG['current_host']
-    assert environment.module_name == 'main'
-    assert environment.module_dir == 'imagenet'
-    assert environment.enable_metrics
-    assert environment.log_level == logging.WARNING
+@pytest.fixture(name='serving_environment')
+def create_serving_environment():
+    with patch('sagemaker_containers.environment.cpu_count', lambda: 8), \
+         patch('sagemaker_containers.environment.gpu_count', lambda: 4):
+
+        os.environ[smc.environment.USE_NGINX_ENV] = 'false'
+        os.environ[smc.environment.MODEL_SERVER_TIMEOUT_ENV] = '20'
+        os.environ[smc.environment.CURRENT_HOST_ENV] = 'algo-1'
+        os.environ[smc.environment.USER_PROGRAM_PARAM.upper()] = 'main.py'
+        os.environ[smc.environment.SUBMIT_DIR_PARAM.upper()] = 'my_dir'
+        os.environ[smc.environment.ENABLE_METRICS_PARAM.upper()] = 'true'
+        os.environ[smc.environment.REGION_PARAM_NAME.upper()] = 'us-west-2'
+        return smc.environment.ServingEnvironment.create(session=Mock())
 
 
-def test_environment_properties(environment):
-    assert environment.properties() == ['channel_input_dirs', 'current_host', 'enable_metrics', 'hosts',
-                                        'hyperparameters', 'input_config_dir', 'input_data_config', 'input_dir',
-                                        'log_level', 'model_dir', 'module_dir', 'module_name', 'num_cpu', 'num_gpu',
-                                        'output_data_dir', 'output_dir', 'resource_config']
+def test_train_environment_create(training_environment):
+    assert training_environment.num_gpu == 4
+    assert training_environment.num_cpu == 8
+    assert training_environment.input_dir == '/opt/ml/input'
+    assert training_environment.input_config_dir == '/opt/ml/input/config'
+    assert training_environment.model_dir == '/opt/ml/model'
+    assert training_environment.output_dir == '/opt/ml/output'
+    assert training_environment.hyperparameters == USER_HYPERPARAMETERS
+    assert training_environment.resource_config == RESOURCE_CONFIG
+    assert training_environment.input_data_config == INPUT_DATA_CONFIG
+    assert training_environment.output_data_dir == '/opt/ml/output/data'
+    assert training_environment.hosts == RESOURCE_CONFIG['hosts']
+    assert training_environment.channel_input_dirs['train'] == '/opt/ml/input/data/train'
+    assert training_environment.channel_input_dirs['validation'] == '/opt/ml/input/data/validation'
+    assert training_environment.current_host == RESOURCE_CONFIG['current_host']
+    assert training_environment.module_name == 'main'
+    assert training_environment.module_dir == 'imagenet'
+    assert training_environment.enable_metrics
+    assert training_environment.log_level == logging.WARNING
 
 
-def test_environment_dictionary(environment):
-    assert len(environment) == len(environment.properties())
-
-    assert environment['num_gpu'] == 4
-    assert environment['num_cpu'] == 8
-    assert environment['input_dir'] == '/opt/ml/input'
-    assert environment['input_config_dir'] == '/opt/ml/input/config'
-    assert environment['model_dir'] == '/opt/ml/model'
-    assert environment['output_dir'] == '/opt/ml/output'
-    assert environment['hyperparameters'] == USER_HYPERPARAMETERS
-    assert environment['resource_config'] == RESOURCE_CONFIG
-    assert environment['input_data_config'] == INPUT_DATA_CONFIG
-    assert environment['output_data_dir'] == '/opt/ml/output/data'
-    assert environment['hosts'] == RESOURCE_CONFIG['hosts']
-    assert environment['channel_input_dirs']['train'] == '/opt/ml/input/data/train'
-    assert environment['channel_input_dirs']['validation'] == '/opt/ml/input/data/validation'
-    assert environment['current_host'] == RESOURCE_CONFIG['current_host']
-    assert environment['module_name'] == 'main'
-    assert environment['module_dir'] == 'imagenet'
-    assert environment['enable_metrics']
-    assert environment['log_level'] == logging.WARNING
+def test_serve_environment_create(serving_environment):
+    assert serving_environment.num_gpu == 4
+    assert serving_environment.num_cpu == 8
+    assert serving_environment.use_nginx is False
+    assert serving_environment.model_server_timeout == 20
+    assert serving_environment.model_server_workers == 8
+    assert serving_environment.module_name == 'main'
+    assert serving_environment.enable_metrics
 
 
-def test_environment_dictionary_get_exception(environment):
+def test_train_environment_properties(training_environment):
+    assert training_environment.properties() == ['channel_input_dirs', 'current_host', 'enable_metrics', 'hosts',
+                                                 'hyperparameters', 'input_config_dir', 'input_data_config',
+                                                 'input_dir', 'log_level', 'model_dir', 'module_dir', 'module_name',
+                                                 'num_cpu', 'num_gpu', 'output_data_dir', 'output_dir',
+                                                 'resource_config']
+
+
+def test_environment_dictionary(training_environment):
+    assert len(training_environment) == len(training_environment.properties())
+
+    assert training_environment['num_gpu'] == 4
+    assert training_environment['num_cpu'] == 8
+    assert training_environment['input_dir'] == '/opt/ml/input'
+    assert training_environment['input_config_dir'] == '/opt/ml/input/config'
+    assert training_environment['model_dir'] == '/opt/ml/model'
+    assert training_environment['output_dir'] == '/opt/ml/output'
+    assert training_environment['hyperparameters'] == USER_HYPERPARAMETERS
+    assert training_environment['resource_config'] == RESOURCE_CONFIG
+    assert training_environment['input_data_config'] == INPUT_DATA_CONFIG
+    assert training_environment['output_data_dir'] == '/opt/ml/output/data'
+    assert training_environment['hosts'] == RESOURCE_CONFIG['hosts']
+    assert training_environment['channel_input_dirs']['train'] == '/opt/ml/input/data/train'
+    assert training_environment['channel_input_dirs']['validation'] == '/opt/ml/input/data/validation'
+    assert training_environment['current_host'] == RESOURCE_CONFIG['current_host']
+    assert training_environment['module_name'] == 'main'
+    assert training_environment['module_dir'] == 'imagenet'
+    assert training_environment['enable_metrics']
+    assert training_environment['log_level'] == logging.WARNING
+
+
+def test_environment_dictionary_get_exception(serving_environment):
     with pytest.raises(KeyError) as e:
-        environment['non_existent_field']
+        serving_environment['non_existent_field']
 
     assert str(e.value.args[0]) == 'Trying to access invalid key non_existent_field'
 
 
 @pytest.mark.parametrize('sagemaker_program', ['program.py', 'program'])
-def test_environment_module_name(sagemaker_program, environment):
-    env_dict = dict(environment)
+def test_environment_module_name(sagemaker_program, training_environment):
+    env_dict = dict(training_environment)
     del env_dict['module_name']
 
-    env = smc.environment.Environment(module_name=sagemaker_program, **env_dict)
+    env = smc.environment.TrainingEnvironment(module_name=sagemaker_program, **env_dict)
     assert env.module_name == 'program'


### PR DESCRIPTION
Added a base Environment class which handles the common fields and logic
and TrainingEnvironment and ServingEnvironment which are used for each
container type.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
