### PR TITLE
Move processing of requirements file out to the specific container.

### DIFF
--- a/src/container_support/environment.py
+++ b/src/container_support/environment.py
@@ -114,6 +114,8 @@ class ContainerEnvironment(object):
             logger.info('installing requirements in {} via pip'.format(requirements_file))
             output = subprocess.check_output(['pip', 'install', '-r', requirements_file])
             logger.info(output)
+        else:
+            logger.warn('Requirements file:{} was not found'.format(requirements_file))
 
     def start_metrics_if_enabled(self):
         if self.enable_cloudwatch_metrics:

--- a/src/container_support/training.py
+++ b/src/container_support/training.py
@@ -32,8 +32,6 @@ class Trainer(object):
             env.start_metrics_if_enabled()
             base_dir = env.base_dir
 
-            env.pip_install_requirements()
-
             fw = TrainingEnvironment.load_framework()
             fw.train()
             env.write_success_file()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/139

*Description of changes:*
The code to process the requirement file must happen after the code is downloaded. Remove the
call here and add that in specific container. Related PR:
https://github.com/aws/sagemaker-tensorflow-containers/pull/35

Add warning message when this file is not present.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
