### PR TITLE
Do dynamic path expansion at runtime.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,13 +16,11 @@ import os
 import time
 
 import boto3
-from mock import patch
 import numpy as np
 import pytest
 import sagemaker
 import six
 
-import sagemaker_containers.environment as environment
 
 logger = logging.getLogger(__name__)
 
@@ -46,11 +44,9 @@ def override_opt_ml_path(tmpdir):
     input_data.mkdir('config')
     input_data.mkdir('data')
     tmpdir.mkdir('model')
-
-    with patch.dict('os.environ', {'BASE_PATH': str(tmpdir)}):
-        six.moves.reload_module(environment)
-        yield tmpdir
-    six.moves.reload_module(environment)
+    os.environ['BASE_PATH'] = str(tmpdir)
+    yield tmpdir
+    del os.environ['BASE_PATH']
 
 
 @pytest.fixture(name='input_path')

--- a/test/unit/test_environment.py
+++ b/test/unit/test_environment.py
@@ -98,6 +98,26 @@ def test_channel_input_dirs(input_data_path):
     assert smc.environment.channel_path('training') == str(input_data_path.join('training'))
 
 
+def test_expand_base_path_with_default():
+    if smc.environment.BASE_PATH_ENV in os.environ:
+        del os.environ[smc.environment.BASE_PATH_ENV]
+
+    path = '{}/my/path'
+    expanded = smc.environment.expand_base_path(path)
+
+    assert expanded == '/opt/ml/my/path'
+
+
+def test_expand_base_path_with_custom_base():
+    path = '{}/my/path'
+    os.environ[smc.environment.BASE_PATH_ENV] = '/root/of/all/evil'
+
+    expanded = smc.environment.expand_base_path(path)
+
+    del os.environ[smc.environment.BASE_PATH_ENV]
+    assert expanded == '/root/of/all/evil/my/path'
+
+
 @patch('subprocess.check_output', lambda s: six.b('GPU 0\nGPU 1'))
 def test_gpu_count_in_gpu_instance():
     assert smc.environment.gpu_count() == 2


### PR DESCRIPTION
Instead of evaluating the custom paths at module import time, expand
the paths when the functions that use them get called. This also helps
making testing simpler as it avoids doing module reloads which have
nasty side effects.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
