### PR TITLE
Change module name to string in __all__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+1.0.dev4
+========
+
+* bug: Configuration: Change module names to string in __all__
+
 1.0.3
 =====
 

--- a/src/container_support/__init__.py
+++ b/src/container_support/__init__.py
@@ -18,5 +18,5 @@ from container_support.serving import Server
 from container_support.training import Trainer
 from container_support.utils import parse_s3_url, download_s3_resource, untar_directory
 
-__all__ = [ContainerEnvironment, TrainingEnvironment, HostingEnvironment, Trainer, Server,
-           retry, parse_s3_url, download_s3_resource, untar_directory, configure_logging]
+__all__ = ['ContainerEnvironment', 'TrainingEnvironment', 'HostingEnvironment', 'Trainer', 'Server',
+           'retry', 'parse_s3_url', 'download_s3_resource', 'untar_directory', 'configure_logging']


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change the module name in __all__ into strings. To perform wild import, string type of module names are required in __all__.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
