### PR TITLE
Hardcode special case for tuning job hyperparameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ CHANGELOG
 ========
 
 * bug: Configuration: Change module names to string in __all__
+* bug: Environment: handle hyperparameter injected by tuning jobs
 
 1.0.3
 =====

--- a/src/container_support/environment.py
+++ b/src/container_support/environment.py
@@ -226,7 +226,18 @@ class TrainingEnvironment(ContainerEnvironment):
     # TODO expecting serialized hyperparams might break containers that aren't launched by python sdk
     @staticmethod
     def _deserialize_hyperparameters(hp):
-        return {k: json.loads(v) for (k, v) in hp.items()}
+        hyperparameter_dict = {}
+
+        for (k, v) in hp.items():
+            # Tuning jobs inject a hyperparameter that does not conform to the JSON format
+            if k == '_tuning_objective_metric':
+                if v.startswith('"') and v.endswith('"'):
+                    v = v[1:-1]
+                hyperparameter_dict[k] = v
+            else:
+                hyperparameter_dict[k] = json.loads(v)
+
+        return hyperparameter_dict
 
     def write_success_file(self):
         TrainingEnvironment.ensure_directory(self.output_dir)

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -278,6 +278,28 @@ def test_import_user_module_without_py(import_module, training):
     import_module.assert_called_with('nopy')
 
 
+def test_deserialize_hyperparameters_for_tuning_jobs(training):
+    os.environ[TrainingEnvironment.TRAINING_JOB_ENV.upper()] = 'training_job_name'
+
+    d = optml(['input/data/training', 'input/config', 'model', 'output/data'])
+
+    with open(os.path.join(d, 'input/data/training/data.csv'), 'w') as f:
+        f.write('dummy data file')
+
+    _write_resource_config(d, 'algo-1', ['algo-1'])
+    _write_config_file(d, 'inputdataconfig.json', INPUT_DATA_CONFIG)
+
+    hyperparameters = _serialize_hyperparameters(HYPERPARAMETERS)
+    hyperparameters['_tuning_objective_metric'] = 'loss'
+    _write_config_file(d, 'hyperparameters.json', hyperparameters)
+
+    env = TrainingEnvironment(d)
+
+    assert '_tuning_objective_metric' in env.hyperparameters
+
+    shutil.rmtree(d)
+
+
 def _write_config_file(training, filename, data):
     path = os.path.join(training, "input/config/%s" % filename)
     with open(path, 'w') as f:


### PR DESCRIPTION
*Description of changes:*
Tuning jobs inject a hyperparameter that won't be serialized as a well-formed JSON - our containers expect hyperparameters to be serialized, even though they may not be. This change is a hack to take care of the tuning job hyperparameter, but in the future we should probably write some more general logic (see the TODO note at the beginning of the method)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
