### PR TITLE
Backward compatibility support

### DIFF
--- a/src/sagemaker_containers/content_types.py
+++ b/src/sagemaker_containers/content_types.py
@@ -15,3 +15,4 @@ CSV = "text/csv"
 OCTET_STREAM = "application/octet-stream"
 ANY = '*/*'
 NPY = 'application/x-npy'
+UTF8_TYPES = [JSON, CSV]

--- a/src/sagemaker_containers/encoders.py
+++ b/src/sagemaker_containers/encoders.py
@@ -51,6 +51,23 @@ def npy_to_numpy(npy_array):  # type: (object) -> np.array
     return np.load(stream)
 
 
+def unicode_to_str(string_like):  # type: (str or unicode) -> str
+    """Convert unicode in string. If it is array a string, returns itself.
+
+    Args:
+        string_like (str or unicode): string like object to be converted to string
+
+    Returns:
+        (str): converted string
+    """
+    if hasattr(string_like, 'decode'):
+        try:
+            return string_like.decode('utf-8')
+        finally:
+            return string_like.decode('latin1')
+    return string_like
+
+
 def array_to_json(array_like):  # type: (np.array or Iterable or int or float) -> str
     """Convert an array like object to JSON.
 
@@ -72,30 +89,30 @@ def array_to_json(array_like):  # type: (np.array or Iterable or int or float) -
     return json.dumps(array_like, default=default)
 
 
-def json_to_numpy(string):  # type: (object) -> np.array
+def json_to_numpy(string_like):  # type: (str or unicode) -> np.array
     """Convert a JSON object to a numpy array.
 
         Args:
-            string (str): JSON string.
+            string_like (str): JSON string.
 
         Returns:
             (np.array): numpy array
         """
-    data = json.loads(string)
+    data = json.loads(unicode_to_str(string_like))
     return np.array(data)
 
 
-def csv_to_numpy(string):  # type: (str) -> np.array
+def csv_to_numpy(string_like):  # type: (str or unicode) -> np.array
     """Convert a CSV object to a numpy array.
 
     Args:
-        string (str): CSV string.
+        string_like (str): CSV string.
 
     Returns:
         (np.array): numpy array
     """
-    stream = StringIO(string)
-    return np.genfromtxt(stream, dtype=np.float32, delimiter=',')
+    stream = StringIO(unicode_to_str(string_like))
+    return np.genfromtxt(stream, delimiter=',')
 
 
 def array_to_csv(array_like):  # type: (np.array or Iterable or int or float) -> str

--- a/src/sagemaker_containers/encoders.py
+++ b/src/sagemaker_containers/encoders.py
@@ -38,17 +38,19 @@ def array_to_npy(array_like):  # type: (np.array or Iterable or int or float) ->
     return buffer.getvalue()
 
 
-def npy_to_numpy(npy_array):  # type: (object) -> np.array
+def npy_to_numpy(npy_array, dtype=np.float32):  # type: (object) -> np.array
     """Convert an NPY array into numpy.
 
     Args:
+        dtype (dtype, optional):  Data type of the resulting array.
+                                    If None, the dtypes will be determined by the contents of each column, individually.
         npy_array (npy array): to be converted to numpy array
 
     Returns:
         (np.array): converted numpy array.
     """
     stream = BytesIO(npy_array)
-    return np.load(stream)
+    return np.load(stream).astype(dtype)
 
 
 def unicode_to_str(string_like):  # type: (str or unicode) -> str
@@ -89,30 +91,34 @@ def array_to_json(array_like):  # type: (np.array or Iterable or int or float) -
     return json.dumps(array_like, default=default)
 
 
-def json_to_numpy(string_like):  # type: (str or unicode) -> np.array
+def json_to_numpy(string_like, dtype=np.float32):  # type: (str or unicode) -> np.array
     """Convert a JSON object to a numpy array.
 
         Args:
+            dtype (dtype, optional):  Data type of the resulting array.
+                                    If None, the dtypes will be determined by the contents of each column, individually.
             string_like (str): JSON string.
 
         Returns:
             (np.array): numpy array
         """
     data = json.loads(unicode_to_str(string_like))
-    return np.array(data)
+    return np.array(data).astype(dtype=dtype)
 
 
-def csv_to_numpy(string_like):  # type: (str or unicode) -> np.array
+def csv_to_numpy(string_like, dtype=np.float32):  # type: (str or unicode) -> np.array
     """Convert a CSV object to a numpy array.
 
     Args:
+        dtype (dtype, optional):  Data type of the resulting array.
+                                    If None, the dtypes will be determined by the contents of each column, individually.
         string_like (str): CSV string.
 
     Returns:
         (np.array): numpy array
     """
     stream = StringIO(unicode_to_str(string_like))
-    return np.genfromtxt(stream, delimiter=',')
+    return np.genfromtxt(stream, dtype=dtype, delimiter=',')
 
 
 def array_to_csv(array_like):  # type: (np.array or Iterable or int or float) -> str

--- a/src/sagemaker_containers/encoders.py
+++ b/src/sagemaker_containers/encoders.py
@@ -38,13 +38,11 @@ def array_to_npy(array_like):  # type: (np.array or Iterable or int or float) ->
     return buffer.getvalue()
 
 
-def npy_to_numpy(npy_array, dtype=np.float32):  # type: (object) -> np.array
+def npy_to_numpy(npy_array):  # type: (object) -> np.array
     """Convert an NPY array into numpy.
 
     Args:
         npy_array (npy array): to be converted to numpy array
-        dtype (dtype, optional):  Data type of the resulting array.
-                                    If None, the dtypes will be determined by the contents of each column, individually.
     Returns:
         (np.array): converted numpy array.
     """
@@ -73,27 +71,29 @@ def array_to_json(array_like):  # type: (np.array or Iterable or int or float) -
     return json.dumps(array_like, default=default)
 
 
-def json_to_numpy(string_like, dtype=np.float32):  # type: (str or unicode) -> np.array
+def json_to_numpy(string_like, dtype=None):  # type: (str or unicode) -> np.array
     """Convert a JSON object to a numpy array.
 
         Args:
             string_like (str): JSON string.
-            dtype (dtype, optional):  Data type of the resulting array.
-                                    If None, the dtypes will be determined by the contents of each column, individually.
+            dtype (dtype, optional):  Data type of the resulting array. If None, the dtypes will be determined by the
+                                        contents of each column, individually. This argument can only be used to
+                                        'upcast' the array.  For downcasting, use the .astype(t) method.
         Returns:
             (np.array): numpy array
         """
     data = json.loads(string_like)
-    return np.array(data).astype(dtype=dtype)
+    return np.array(data, dtype=dtype)
 
 
-def csv_to_numpy(string_like, dtype=np.float32):  # type: (str or unicode) -> np.array
+def csv_to_numpy(string_like, dtype=None):  # type: (str or unicode) -> np.array
     """Convert a CSV object to a numpy array.
 
     Args:
         string_like (str): CSV string.
-        dtype (dtype, optional):  Data type of the resulting array.
-                                    If None, the dtypes will be determined by the contents of each column, individually.
+        dtype (dtype, optional):  Data type of the resulting array. If None, the dtypes will be determined by the
+                                        contents of each column, individually. This argument can only be used to
+                                        'upcast' the array.  For downcasting, use the .astype(t) method.
     Returns:
         (np.array): numpy array
     """

--- a/src/sagemaker_containers/encoders.py
+++ b/src/sagemaker_containers/encoders.py
@@ -42,32 +42,14 @@ def npy_to_numpy(npy_array, dtype=np.float32):  # type: (object) -> np.array
     """Convert an NPY array into numpy.
 
     Args:
+        npy_array (npy array): to be converted to numpy array
         dtype (dtype, optional):  Data type of the resulting array.
                                     If None, the dtypes will be determined by the contents of each column, individually.
-        npy_array (npy array): to be converted to numpy array
-
     Returns:
         (np.array): converted numpy array.
     """
     stream = BytesIO(npy_array)
-    return np.load(stream).astype(dtype)
-
-
-def unicode_to_str(string_like):  # type: (str or unicode) -> str
-    """Convert unicode in string. If it is array a string, returns itself.
-
-    Args:
-        string_like (str or unicode): string like object to be converted to string
-
-    Returns:
-        (str): converted string
-    """
-    if hasattr(string_like, 'decode'):
-        try:
-            return string_like.decode('utf-8')
-        finally:
-            return string_like.decode('latin1')
-    return string_like
+    return np.load(stream)
 
 
 def array_to_json(array_like):  # type: (np.array or Iterable or int or float) -> str
@@ -95,14 +77,13 @@ def json_to_numpy(string_like, dtype=np.float32):  # type: (str or unicode) -> n
     """Convert a JSON object to a numpy array.
 
         Args:
+            string_like (str): JSON string.
             dtype (dtype, optional):  Data type of the resulting array.
                                     If None, the dtypes will be determined by the contents of each column, individually.
-            string_like (str): JSON string.
-
         Returns:
             (np.array): numpy array
         """
-    data = json.loads(unicode_to_str(string_like))
+    data = json.loads(string_like)
     return np.array(data).astype(dtype=dtype)
 
 
@@ -110,14 +91,13 @@ def csv_to_numpy(string_like, dtype=np.float32):  # type: (str or unicode) -> np
     """Convert a CSV object to a numpy array.
 
     Args:
+        string_like (str): CSV string.
         dtype (dtype, optional):  Data type of the resulting array.
                                     If None, the dtypes will be determined by the contents of each column, individually.
-        string_like (str): CSV string.
-
     Returns:
         (np.array): numpy array
     """
-    stream = StringIO(unicode_to_str(string_like))
+    stream = StringIO(string_like)
     return np.genfromtxt(stream, dtype=dtype, delimiter=',')
 
 

--- a/src/sagemaker_containers/env.py
+++ b/src/sagemaker_containers/env.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import tempfile
 
+
 from sagemaker_containers import mapping
 
 logger = logging.getLogger(__name__)
@@ -165,7 +166,7 @@ def channel_path(channel):  # type: (str) -> str
     For more information about channels: https://docs.aws.amazon.com/sagemaker/latest/dg/API_Channel.html
 
     Returns:
-        (str) The input data directory for the specified channel.
+        str: The input data directory for the specified channel.
     """
     return os.path.join(INPUT_DATA_PATH, channel)
 
@@ -174,7 +175,7 @@ def gpu_count():  # type: () -> int
     """The number of gpus available in the current container.
 
     Returns:
-        (int): number of gpus available in the current container.
+        int: number of gpus available in the current container.
     """
     try:
         cmd = shlex.split('nvidia-smi --list-gpus')
@@ -189,7 +190,7 @@ def cpu_count():  # type: () -> int
     """The number of cpus available in the current container.
 
     Returns:
-        (int): number of cpus available in the current container.
+        int: number of cpus available in the current container.
     """
     return multiprocessing.cpu_count()
 
@@ -228,14 +229,14 @@ class Env(mapping.MappingMixin):
     @property
     def model_dir(self):  # type: () -> str
         """Returns:
-            (str): the directory where models should be saved, e.g., /opt/ml/model/"""
+            str: the directory where models should be saved, e.g., /opt/ml/model/"""
         return self._model_dir
 
     @property
     def current_host(self):  # type: () -> str
         """The name of the current container on the container network. For example, 'algo-1'.
         Returns:
-            (str): current host.
+            str: current host.
         """
         return self._current_host
 
@@ -244,7 +245,7 @@ class Env(mapping.MappingMixin):
         """The number of gpus available in the current container.
 
         Returns:
-            (int): number of gpus available in the current container.
+            int: number of gpus available in the current container.
         """
         return self._num_gpus
 
@@ -253,7 +254,7 @@ class Env(mapping.MappingMixin):
         """The number of cpus available in the current container.
 
         Returns:
-            (int): number of cpus available in the current container.
+            int: number of cpus available in the current container.
         """
         return self._num_cpus
 
@@ -262,7 +263,7 @@ class Env(mapping.MappingMixin):
         """The name of the user provided module.
 
         Returns:
-            (str): name of the user provided module
+            str: name of the user provided module
         """
         return self._parse_module_name(self._module_name)
 
@@ -271,7 +272,7 @@ class Env(mapping.MappingMixin):
         """The full path location of the user provided module.
 
         Returns:
-            (str): full path location of the user provided module.
+            str: full path location of the user provided module.
         """
         return self._module_dir
 
@@ -280,7 +281,7 @@ class Env(mapping.MappingMixin):
         """Whether metrics should be executed in the environment or not.
 
         Returns:
-            (bool): representing whether metrics should be executed or not.
+            bool: representing whether metrics should be executed or not.
         """
         return self._enable_metrics
 
@@ -289,7 +290,7 @@ class Env(mapping.MappingMixin):
         """Environment logging level.
 
         Returns:
-            (int): environment logging level.
+            int: environment logging level.
         """
         return self._log_level
 
@@ -303,7 +304,7 @@ class Env(mapping.MappingMixin):
             program_param (str): Module or script name.
 
         Returns:
-            (str): Module name
+            str: Module name
         """
         if program_param and program_param.endswith('.py'):
             return program_param[:-3]
@@ -475,7 +476,7 @@ class TrainingEnv(Env):
         """The list of names of all containers on the container network, sorted lexicographically.
                 For example, `["algo-1", "algo-2", "algo-3"]` for a three-node cluster.
         Returns:
-              (list[str]): all the hosts in the training network.
+              list[str]: all the hosts in the training network.
         """
         return self._hosts
 
@@ -484,7 +485,7 @@ class TrainingEnv(Env):
         """Name of the network interface used for distributed training
 
         Returns:
-              (str): name of the network interface, for example, 'ethwe'
+              str: name of the network interface, for example, 'ethwe'
         """
         return self._network_interface_name
 
@@ -495,7 +496,7 @@ class TrainingEnv(Env):
         The input data directory has the following subdirectories:
             config (`input_config_dir`) and data (`input_data_dir`)
         Returns:
-            (str): the path of the input directory, e.g. /opt/ml/input/
+            str: the path of the input directory, e.g. /opt/ml/input/
         """
         return self._input_dir
 
@@ -512,7 +513,7 @@ class TrainingEnv(Env):
         More information about this files can be find here:
             https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo.html
         Returns:
-            (str): the path of the input directory, e.g. /opt/ml/input/config/
+            str: the path of the input directory, e.g. /opt/ml/input/config/
         """
         return self._input_config_dir
 
@@ -521,7 +522,7 @@ class TrainingEnv(Env):
         """The directory where training success/failure indications will be written, e.g. /opt/ml/output.
         To save non-model artifacts check `output_data_dir`.
         Returns:
-            (str): the path to the output directory, e.g. /opt/ml/output/.
+            str: the path to the output directory, e.g. /opt/ml/output/.
         """
         return self._output_dir
 
@@ -530,7 +531,7 @@ class TrainingEnv(Env):
         """The dict of hyperparameters that were passed to the training job.
 
         Returns:
-            hyperparameters (dict[str, object]): An instance of `HyperParameters` containing the training job
+            dict[str, object]: An instance of `HyperParameters` containing the training job
                                                     hyperparameters.
         """
         return self._hyperparameters
@@ -586,7 +587,7 @@ class TrainingEnv(Env):
         training job and model and output artifacts. Your algorithm should write this information
         to the this directory.
         Returns:
-            (str): the path to output data directory, e.g. /opt/ml/output/data/algo-1.
+            str: the path to output data directory, e.g. /opt/ml/output/data/algo-1.
         """
         return self._output_data_dir
 
@@ -608,7 +609,7 @@ class TrainingEnv(Env):
     @property
     def framework_module(self):  # type: () -> str
         """Returns:
-            (str): Name of the framework module and entry point. For example:
+            str: Name of the framework module and entry point. For example:
                 my_module:main"""
         return self._framework_module
 
@@ -653,26 +654,26 @@ class ServingEnv(Env):
     @property
     def use_nginx(self):  # type: () -> bool
         """Returns:
-            (bool): whether to use nginx as a reverse proxy. Default: True"""
+            bool: whether to use nginx as a reverse proxy. Default: True"""
         return self._use_nginx
 
     @property
     def model_server_timeout(self):  # type: () -> int
         """Returns:
-            (int): Timeout in seconds for the model server. This is passed over to gunicorn, from the docs:
+            int: Timeout in seconds for the model server. This is passed over to gunicorn, from the docs:
                 Workers silent for more than this many seconds are killed and restarted. Our default value is 60."""
         return self._model_server_timeout
 
     @property
     def model_server_workers(self):  # type: () -> int
         """Returns:
-            (int): Number of worker processes the model server will use"""
+            int: Number of worker processes the model server will use"""
         return self._model_server_workers
 
     @property
     def framework_module(self):  # type: () -> str
         """Returns:
-            (str): Name of the framework module and entry point. For example:
+            str: Name of the framework module and entry point. For example:
                 my_module:main"""
         return self._framework_module
 
@@ -691,23 +692,20 @@ def tmpdir(suffix='', prefix='tmp', dir=None):  # type: (str, str, str) -> None
         dir (str):  If dir is specified, the file will be created in that directory; otherwise, a default directory is
                         used.
     Returns:
-        (str) path to the directory
+        str: path to the directory
     """
     tmp = tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
     yield tmp
     shutil.rmtree(tmp)
 
 
-def write_file(path, content, mode='w'):  # type: (str, str, str) -> None
-    """Write content to a file.
+def write_file(path, data, mode='w'):  # type: (str, str, str) -> None
+    """Write data to a file.
 
     Args:
         path (str): path to the file.
-        content (str): content to be written to the file.
+        data (str): data to be written to the file.
         mode (str): mode which the file will be open.
-
-    Returns:
-
     """
     with open(path, mode) as f:
-        f.write(content)
+        f.write(data)

--- a/src/sagemaker_containers/env.py
+++ b/src/sagemaker_containers/env.py
@@ -682,3 +682,18 @@ def tmpdir(suffix='', prefix='tmp', dir=None):  # type: (str, str, str) -> None
     tmp = tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
     yield tmp
     shutil.rmtree(tmp)
+
+
+def write_file(path, content, mode='w'):  # type: (str, str, str) -> None
+    """Write content to a file.
+
+    Args:
+        path (str): path to the file.
+        content (str): content to be written to the file.
+        mode (str): mode which the file will be open.
+
+    Returns:
+
+    """
+    with open(path, mode) as f:
+        f.write(content)

--- a/src/sagemaker_containers/errors.py
+++ b/src/sagemaker_containers/errors.py
@@ -1,0 +1,25 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+
+class ClientError(BaseException):
+    pass
+
+
+class InstallModuleError(ClientError):
+    pass
+
+
+class ImportModuleError(ClientError):
+    pass

--- a/src/sagemaker_containers/modules.py
+++ b/src/sagemaker_containers/modules.py
@@ -61,7 +61,7 @@ def prepare(path, name):  # type: (str, str) -> None
     """
     setup_path = os.path.join(path, 'setup.py')
     if not os.path.exists(setup_path):
-        content = textwrap.dedent("""
+        data = textwrap.dedent("""
         from setuptools import setup
 
         setup(packages=[''],
@@ -72,18 +72,18 @@ def prepare(path, name):  # type: (str, str) -> None
 
         logging.info('Module %s does not provide a setup.py. \nGenerating setup.py' % name)
 
-        env.write_file(setup_path, content)
+        env.write_file(setup_path, data)
 
-        content = textwrap.dedent("""
+        data = textwrap.dedent("""
         [wheel]
         universal = 1
         """)
 
         logging.info('Generating setup.cfg')
 
-        env.write_file(os.path.join(path, 'setup.cfg'), content)
+        env.write_file(os.path.join(path, 'setup.cfg'), data)
 
-        content = textwrap.dedent("""
+        data = textwrap.dedent("""
         recursive-include . *
 
         recursive-exclude . __pycache__*
@@ -93,7 +93,7 @@ def prepare(path, name):  # type: (str, str) -> None
 
         logging.info('Generating MANIFEST.in')
 
-        env.write_file(os.path.join(path, 'MANIFEST.in'), content)
+        env.write_file(os.path.join(path, 'MANIFEST.in'), data)
 
 
 def install(path):  # type: (str) -> None

--- a/src/sagemaker_containers/transformer.py
+++ b/src/sagemaker_containers/transformer.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 import textwrap
 
-from sagemaker_containers import encoders, env, functions, worker
+from sagemaker_containers import encoders, env, errors, functions, worker
 
 
 def default_model_fn(model_dir):
@@ -87,10 +87,6 @@ def default_output_fn(prediction, accept):
     return worker.Response(encoders.encode(prediction, accept), accept)
 
 
-class ClientError(BaseException):
-    pass
-
-
 class Transformer(object):
     """The Transformer is a proxy between the worker and the framework transformation functions.
 
@@ -114,7 +110,7 @@ class Transformer(object):
     >>>transformer.load_user_fns(mod)
     """
 
-    def __init__(self, model_fn=None, input_fn=None, predict_fn=None, output_fn=None, error_class=ClientError):
+    def __init__(self, model_fn=None, input_fn=None, predict_fn=None, output_fn=None, error_class=errors.ClientError):
         """Default constructor. Wraps the any non default framework function in an error class to isolate
         framework from user errors.
 

--- a/src/sagemaker_containers/transformer.py
+++ b/src/sagemaker_containers/transformer.py
@@ -54,7 +54,7 @@ def default_input_fn(input_data, content_type):
     return encoders.decode(input_data, content_type)
 
 
-def default_predict_fn(model, data):
+def default_predict_fn(data, model):
     """Function responsible for model predictions.
 
     Args:
@@ -136,7 +136,7 @@ class Transformer(object):
         This function will be called once per each worker.
         It does not have return type or arguments.
         """
-        self._model = self._model_fn(model_dir=env.ServingEnv().model_dir)
+        self._model = self._model_fn(env.ServingEnv().model_dir)
 
     def transform(self):  # type: () -> worker.Response
         """Responsible to make predictions against the model.
@@ -150,9 +150,9 @@ class Transformer(object):
         """
         request = worker.Request()
 
-        data = self._input_fn(input_data=request.content, content_type=request.content_type)
-        prediction = self._predict_fn(model=self._model, data=data)
-        result = self._output_fn(prediction=prediction, accept=request.accept)
+        data = self._input_fn(request.content, request.content_type)
+        prediction = self._predict_fn(data, self._model)
+        result = self._output_fn(prediction, request.accept)
 
         if isinstance(result, tuple):
             # transforms tuple in Response for backwards compatibility

--- a/src/sagemaker_containers/transformer.py
+++ b/src/sagemaker_containers/transformer.py
@@ -40,12 +40,12 @@ def default_input_fn(input_data, content_type):
         the model server receives two pieces of information:
 
             - The request Content-Type, for example "application/json"
-            - The request data content, which is at most 5 MB (5 * 1024 * 1024 bytes) in size.
+            - The request data, which is at most 5 MB (5 * 1024 * 1024 bytes) in size.
 
         The input_fn is responsible to take the request data and pre-process it before prediction.
 
     Args:
-        input_data (obj): the request data content.
+        input_data (obj): the request data.
         content_type (str): the request Content-Type.
 
     Returns:

--- a/src/sagemaker_containers/worker.py
+++ b/src/sagemaker_containers/worker.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 import flask
 
-from sagemaker_containers import content_types, env, mapping, status_codes
+from sagemaker_containers import content_types, encoders, env, mapping, status_codes
 
 serving_env = env.ServingEnv()
 
@@ -146,7 +146,7 @@ class Request(flask.Request, mapping.MappingMixin):
             (obj): incoming data
         """
         data = self.get_data()
-        try:
-            return data.decode('utf-8')
-        except (ValueError, UnicodeDecodeError):
-            return data
+
+        if self.content_type in content_types.UTF8_TYPES:
+            return encoders.unicode_to_str(data)
+        return data

--- a/src/sagemaker_containers/worker.py
+++ b/src/sagemaker_containers/worker.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 import flask
 
-from sagemaker_containers import content_types, encoders, env, mapping, status_codes
+from sagemaker_containers import content_types, env, mapping, status_codes
 
 serving_env = env.ServingEnv()
 
@@ -103,11 +103,11 @@ class Request(flask.Request, mapping.MappingMixin):
     >>> from sagemaker_containers import env
 
     >>> request = env.Request()
-    >>> content = request.content
+    >>> data = request.data
 
     >>> print(str(request))
 
-    {'content_length': '2', 'content_type': 'application/json', 'content': '42', 'accept': 'application/json', ... }
+    {'content_length': '2', 'content_type': 'application/json', 'data': '42', 'accept': 'application/json', ... }
 
 
     """
@@ -145,8 +145,6 @@ class Request(flask.Request, mapping.MappingMixin):
         Returns:
             (obj): incoming data
         """
-        data = self.get_data()
+        as_text = self.content_type in content_types.UTF8_TYPES
 
-        if self.content_type in content_types.UTF8_TYPES:
-            return encoders.unicode_to_str(data)
-        return data
+        return self.get_data(as_text=as_text)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -98,7 +98,7 @@ def create_hyperparameters_config(hyperparameters, submit_dir=None, sagemaker_hy
     write_json(all_hyperparameters, env.HYPERPARAMETERS_PATH)
 
 
-File = collections.namedtuple('File', ['name', 'content'])  # type: (str, str or list) -> File
+File = collections.namedtuple('File', ['name', 'data'])  # type: (str, str or list) -> File
 
 
 def request(path='/', base_url=None, query_string=None, accept=None, method='GET', input_stream=None,
@@ -158,12 +158,12 @@ class UserModule(object):
                     name = os.path.join(tmpdir, _file.name)
                     with open(name, 'w+') as f:
 
-                        if isinstance(_file.content, six.string_types):
-                            content = _file.content
+                        if isinstance(_file.data, six.string_types):
+                            data = _file.data
                         else:
-                            content = '\n'.join(_file.content)
+                            data = '\n'.join(_file.data)
 
-                        f.write(content)
+                        f.write(data)
                     tar.add(name=name, arcname=_file.name)
 
             self._s3.Object(self.bucket, self.key).upload_file(tar_name)

--- a/test/functional/test_download_and_import.py
+++ b/test/functional/test_download_and_import.py
@@ -21,10 +21,10 @@ import pytest
 from sagemaker_containers import errors, modules
 import test
 
-content = ['from distutils.core import setup\n',
-           'setup(name="my_test_script", py_modules=["my_test_script"])']
+data = ['from distutils.core import setup\n',
+        'setup(name="my_test_script", py_modules=["my_test_script"])']
 
-SETUP = test.File('setup.py', content)
+SETUP = test.File('setup.py', data)
 
 USER_SCRIPT = test.File('my_test_script.py', 'def validate(): return True')
 
@@ -55,7 +55,7 @@ def test_download_and_import_script(user_module_name):
     assert module.validate()
 
 
-content = textwrap.dedent("""
+data = textwrap.dedent("""
             from pyfiglet import Figlet
 
             def say():
@@ -63,7 +63,7 @@ content = textwrap.dedent("""
 
 """)
 
-USER_SCRIPT_WITH_REQUIREMENTS = test.File('my_test_script.py', content)
+USER_SCRIPT_WITH_REQUIREMENTS = test.File('my_test_script.py', data)
 
 REQUIREMENTS_FILE = test.File('requirements.txt', 'pyfiglet')
 
@@ -83,7 +83,7 @@ def test_download_and_import_script_with_requirements(user_module_name):
 """.replace('.', ' ').strip()
 
 
-content = textwrap.dedent("""
+data = textwrap.dedent("""
             import file_2
 
 
@@ -91,7 +91,7 @@ content = textwrap.dedent("""
                 return file_2.IMPORTED
 """)
 
-USER_SCRIPT_WITH_ADDITIONAL_FILE = test.File('my_test_script.py', content)
+USER_SCRIPT_WITH_ADDITIONAL_FILE = test.File('my_test_script.py', data)
 
 ADDITIONAL_FILE = test.File('file_2.py', 'IMPORTED = True')
 
@@ -104,9 +104,9 @@ def test_download_and_import_script_with_additional_files(user_module_name):
     assert module.validate()
 
 
-content = ['raise ValueError("this script does not work")']
+data = ['raise ValueError("this script does not work")']
 
-USER_SCRIPT_WITH_ERROR = test.File('my_test_script.py', content)
+USER_SCRIPT_WITH_ERROR = test.File('my_test_script.py', data)
 
 
 def test_download_and_import_script_with_error(user_module_name):

--- a/test/functional/test_download_and_import.py
+++ b/test/functional/test_download_and_import.py
@@ -73,11 +73,8 @@ def test_download_and_import_script_with_requirements(user_module_name):
 
     module = modules.download_and_import(user_module.url, user_module_name, cache=False)
 
-    say = module.say()
-    print(say)
-
     # flake8: noqa ignore=W291 trailing whitespace
-    assert say == """
+    assert module.say() == """
  ____                   __  __       _             
 / ___|  __ _  __ _  ___|  \/  | __ _| | _____ _ __ 
 \___ \ / _` |/ _` |/ _ \ |\/| |/ _` | |/ / _ \ '__|

--- a/test/functional/test_download_and_import.py
+++ b/test/functional/test_download_and_import.py
@@ -12,45 +12,109 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-from sagemaker_containers import modules
+import shlex
+import subprocess
+import textwrap
+
+import pytest
+
+from sagemaker_containers import errors, modules
 import test
 
 content = ['from distutils.core import setup\n',
-           'setup(name="test_script", py_modules=["test_script"])']
+           'setup(name="my_test_script", py_modules=["my_test_script"])']
 
 SETUP = test.File('setup.py', content)
 
-USER_SCRIPT = test.File('test_script.py', 'def validate(): return True')
+USER_SCRIPT = test.File('my_test_script.py', 'def validate(): return True')
 
 
-def test_download_and_import_module():
+@pytest.fixture(name='user_module_name')
+def erase_user_module():
+    user_module = 'my_test_script'
+    yield user_module
+    try:
+        subprocess.check_call(shlex.split('pip uninstall -y --quiet %s' % user_module))
+    except subprocess.CalledProcessError:
+        pass
+
+
+def test_download_and_import_module(user_module_name):
     user_module = test.UserModule(USER_SCRIPT).add_file(SETUP).upload()
 
-    module = modules.download_and_import(user_module.url, 'test_script')
+    module = modules.download_and_import(user_module.url, user_module_name, cache=False)
 
     assert module.validate()
 
 
-def test_download_and_import_script():
+def test_download_and_import_script(user_module_name):
     user_module = test.UserModule(USER_SCRIPT).upload()
 
-    module = modules.download_and_import(user_module.url, 'test_script')
+    module = modules.download_and_import(user_module.url, user_module_name, cache=False)
 
     assert module.validate()
 
 
-content = ['import os',
-           'def validate():',
-           '    return os.path.exist("requirements.txt")']
+content = textwrap.dedent("""
+            from pyfiglet import Figlet
 
-USER_SCRIPT_WITH_REQUIREMENTS = test.File('test_script.py', content)
+            def say():
+                return Figlet().renderText('SageMaker').strip()
 
-REQUIREMENTS_FILE = test.File('requirements.txt', ['keras', 'h5py'])
+""")
+
+USER_SCRIPT_WITH_REQUIREMENTS = test.File('my_test_script.py', content)
+
+REQUIREMENTS_FILE = test.File('requirements.txt', 'pyfiglet')
 
 
-def test_download_and_import_script_with_requirements():
+def test_download_and_import_script_with_requirements(user_module_name):
     user_module = test.UserModule(USER_SCRIPT_WITH_REQUIREMENTS).add_file(REQUIREMENTS_FILE).upload()
 
-    module = modules.download_and_import(user_module.url, 'test_script')
+    module = modules.download_and_import(user_module.url, user_module_name, cache=False)
+
+    say = module.say()
+    print(say)
+
+    # flake8: noqa ignore=W291 trailing whitespace
+    assert say == """
+ ____                   __  __       _             
+/ ___|  __ _  __ _  ___|  \/  | __ _| | _____ _ __ 
+\___ \ / _` |/ _` |/ _ \ |\/| |/ _` | |/ / _ \ '__|
+ ___) | (_| | (_| |  __/ |  | | (_| |   <  __/ |   
+|____/ \__,_|\__, |\___|_|  |_|\__,_|_|\_\___|_|   
+             |___/                                 
+""".strip()
+
+
+content = textwrap.dedent("""
+            import file_2
+
+
+            def validate():
+                return file_2.IMPORTED
+""")
+
+USER_SCRIPT_WITH_ADDITIONAL_FILE = test.File('my_test_script.py', content)
+
+ADDITIONAL_FILE = test.File('file_2.py', 'IMPORTED = True')
+
+
+def test_download_and_import_script_with_additional_files(user_module_name):
+    user_module = test.UserModule(USER_SCRIPT_WITH_ADDITIONAL_FILE).add_file(ADDITIONAL_FILE).upload()
+
+    module = modules.download_and_import(user_module.url, user_module_name, cache=False)
 
     assert module.validate()
+
+
+content = ['raise ValueError("this script does not work")']
+
+USER_SCRIPT_WITH_ERROR = test.File('my_test_script.py', content)
+
+
+def test_download_and_import_script_with_error(user_module_name):
+    user_module = test.UserModule(USER_SCRIPT_WITH_ERROR).upload()
+
+    with pytest.raises(errors.ImportModuleError):
+        modules.download_and_import(user_module.url, user_module_name, cache=False)

--- a/test/functional/test_training_framework.py
+++ b/test/functional/test_training_framework.py
@@ -83,7 +83,7 @@ def test_training_framework(user_script):
     labels = [0, 1, 0, 1]
     np.savez(os.path.join(channel.path, 'training_data'), features=features, labels=labels)
 
-    module = test.UserModule(test.File(name='user_script.py', content=user_script))
+    module = test.UserModule(test.File(name='user_script.py', data=user_script))
 
     hyperparameters = dict(training_data_file='training_data.npz', sagemaker_program='user_script.py',
                            epochs=10, batch_size=64)

--- a/test/functional/test_transformer_implementation.py
+++ b/test/functional/test_transformer_implementation.py
@@ -48,12 +48,12 @@ def test_transformer_implementation():
 
         assert response.status_code == status_codes.OK
 
-        assert response.get_data().decode('utf-8') == '[36.0, 81.0, 1764.0]'
+        assert response.get_data(as_text=True) == '[36.0, 81.0, 1764.0]'
 
         response = post(client, payload, content_types.JSON, content_types.CSV)
 
         assert response.status_code == status_codes.OK
-        assert response.get_data().decode('utf-8') == '36.0\n81.0\n1764.0\n'
+        assert response.get_data(as_text=True) == '36.0\n81.0\n1764.0\n'
 
         response = post(client, payload, content_types.CSV, content_types.NPY)
 

--- a/test/functional/test_transformer_implementation.py
+++ b/test/functional/test_transformer_implementation.py
@@ -21,7 +21,7 @@ import test
 from test import fake_ml_framework
 
 
-def predict_fn(model, data):
+def predict_fn(data, model):
     return model.predict(data)
 
 

--- a/test/functional/test_worker_with_transform.py
+++ b/test/functional/test_worker_with_transform.py
@@ -48,7 +48,7 @@ def test_worker_with_initialize():
             assert response.status_code == status_codes.OK
 
         response = client.post('/invocations')
-        assert json.loads(response.get_data().decode('utf-8')) == dict(initialize=1, transform=10)
+        assert json.loads(response.get_data(as_text=True)) == dict(initialize=1, transform=10)
         assert response.mimetype == content_types.JSON
 
 
@@ -68,7 +68,7 @@ def test_worker(module_name, expected_name):
             assert response.status_code == status_codes.OK
 
         response = client.post('/invocations')
-        assert json.loads(response.get_data().decode('utf-8')) == dict(initialize=0, transform=10)
+        assert json.loads(response.get_data(as_text=True)) == dict(initialize=0, transform=10)
         assert response.mimetype == content_types.JSON
 
 
@@ -83,4 +83,4 @@ def test_worker_with_custom_ping():
                        module_name='custom_ping').test_client() as client:
         response = client.get('/ping')
         assert response.status_code == status_codes.ACCEPTED
-        assert response.get_data().decode('utf-8') == 'ping'
+        assert response.get_data(as_text=True) == 'ping'

--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -52,7 +52,7 @@ def test_csv_to_numpy(string_io, genfromtxt):
     encoders.csv_to_numpy('42')
 
     string_io.assert_called_with('42')
-    genfromtxt.assert_called_with(string_io(), dtype=np.float32, delimiter=',')
+    genfromtxt.assert_called_with(string_io(), delimiter=',')
 
 
 @patch('numpy.savetxt', autospec=True)

--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -13,53 +13,92 @@
 from mock import Mock, patch
 import numpy as np
 import pytest
+from six import BytesIO
 
 from sagemaker_containers import content_types, encoders
 
 
-@patch('numpy.load', lambda x: np.array([42]))
-@patch('sagemaker_containers.encoders.BytesIO', lambda x: 'byte io %s' % x)
-def test_npy_to_numpy():
-    assert encoders.npy_to_numpy(42) == np.array([42])
+@pytest.mark.parametrize('target', ([42, 6, 9], [42., 6., 9.], ['42', '6', '9'], [u'42', u'6', u'9'], {42: {'6': 9.}}))
+def test_npy_to_numpy(target):
+    buffer = BytesIO()
+    np.save(buffer, target)
+    input_data = buffer.getvalue()
+
+    actual = encoders.npy_to_numpy(input_data)
+
+    np.testing.assert_equal(actual, np.array(target))
 
 
-@patch('numpy.save', autospec=True)
-@patch('sagemaker_containers.encoders.BytesIO', autospec=True)
-def array_to_npy(bytes_io, save):
-    encoders.array_to_npy(42)
+@pytest.mark.parametrize('target', ([42, 6, 9], [42., 6., 9.], ['42', '6', '9'], [u'42', u'6', u'9'], {42: {'6': 9.}}))
+def test_array_to_npy(target):
+    input_data = np.array(target)
 
-    bytes_io.return_value.getvalue.assert_called()
-    save.assert_called_with(bytes_io(), 42)
+    actual = encoders.array_to_npy(input_data)
 
+    np.testing.assert_equal(np.load(BytesIO(actual)), np.array(target))
 
-@patch('json.loads', lambda x: [42.324])
-def test_json_to_numpy():
-    assert encoders.json_to_numpy(42) == np.array([42.324], dtype=np.float32)
+    actual = encoders.array_to_npy(target)
 
-    assert encoders.json_to_numpy(42, dtype=int) == np.array([42])
+    np.testing.assert_equal(np.load(BytesIO(actual)), np.array(target))
 
 
-def test_array_to_json():
-    assert encoders.array_to_json(42) == '42'
+@pytest.mark.parametrize(
+    'target, expected', [('[42, 6, 9]', np.array([42, 6, 9])),
+                         ('[42.0, 6.0, 9.0]', np.array([42., 6., 9.])),
+                         ('["42", "6", "9"]', np.array(['42', '6', '9'])),
+                         (u'["42", "6", "9"]', np.array([u'42', u'6', u'9']))]
+)
+def test_json_to_numpy(target, expected):
+    actual = encoders.json_to_numpy(target)
+    np.testing.assert_equal(actual, expected)
 
-    assert encoders.array_to_json(np.asarray([42])) == '[42]'
+    np.testing.assert_equal(encoders.json_to_numpy(target, dtype=int), expected.astype(int))
 
+    np.testing.assert_equal(encoders.json_to_numpy(target, dtype=float), expected.astype(float))
+
+
+@pytest.mark.parametrize(
+    'target, expected', [([42, 6, 9], '[42, 6, 9]'),
+                         ([42., 6., 9.], '[42.0, 6.0, 9.0]'),
+                         (['42', '6', '9'], '["42", "6", "9"]'),
+                         ({42: {'6': 9.}}, '{"42": {"6": 9.0}}')]
+)
+def test_array_to_json(target, expected):
+    actual = encoders.array_to_json(target)
+    np.testing.assert_equal(actual, expected)
+
+    actual = encoders.array_to_json(np.array(target))
+    np.testing.assert_equal(actual, expected)
+
+
+def test_array_to_json_exception():
     with pytest.raises(TypeError):
         encoders.array_to_json(lambda x: 3)
 
 
-def test_csv_to_numpy():
-    assert encoders.csv_to_numpy('42.324') == np.array([42.324], dtype=np.float32)
-    assert encoders.csv_to_numpy('42.324', dtype=np.int32) == np.array([42], dtype=int)
+@pytest.mark.parametrize(
+    'target, expected', [('42\n6\n9\n', np.array([42, 6, 9])),
+                         ('42.0\n6.0\n9.0\n', np.array([42., 6., 9.])),
+                         ('42\n6\n9\n', np.array([42, 6, 9]))]
+)
+def test_csv_to_numpy(target, expected):
+    actual = encoders.csv_to_numpy(target)
+    np.testing.assert_equal(actual, expected)
+
+    actual = encoders.csv_to_numpy(target)
+    np.testing.assert_equal(actual, expected)
 
 
-@patch('numpy.savetxt', autospec=True)
-@patch('sagemaker_containers.encoders.StringIO', autospec=True)
-def test_array_to_csv(string_io, savetxt):
-    encoders.array_to_csv(42)
+@pytest.mark.parametrize(
+    'target, expected', [([42, 6, 9], '42\n6\n9\n'),
+                         ([42., 6., 9.], '42.0\n6.0\n9.0\n'),
+                         (['42', '6', '9'], '42\n6\n9\n')])
+def test_array_to_csv(target, expected):
+    actual = encoders.array_to_csv(target)
+    np.testing.assert_equal(actual, expected)
 
-    string_io.return_value.getvalue.assert_called()
-    savetxt.assert_called_with(string_io(), 42, delimiter=',', fmt='%s')
+    actual = encoders.array_to_csv(np.array(target))
+    np.testing.assert_equal(actual, expected)
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_environment.py
+++ b/test/unit/test_environment.py
@@ -98,7 +98,7 @@ def test_channel_input_dirs():
     assert env.channel_path('training') == os.path.join(input_data_path, 'training')
 
 
-@patch('subprocess.check_output', lambda s: six.b('GPU 0\nGPU 1'))
+@patch('subprocess.check_output', lambda s: b'GPU 0\nGPU 1')
 def test_gpu_count_in_gpu_instance():
     assert env.gpu_count() == 2
 

--- a/test/unit/test_environment.py
+++ b/test/unit/test_environment.py
@@ -149,7 +149,7 @@ def test_train_env(training_env):
     assert training_env.hyperparameters == USER_HYPERPARAMETERS
     assert training_env.resource_config == RESOURCE_CONFIG
     assert training_env.input_data_config == INPUT_DATA_CONFIG
-    assert training_env.output_data_dir.endswith('/opt/ml/output/data')
+    assert training_env.output_data_dir.endswith('/opt/ml/output/data/algo-1')
     assert training_env.hosts == RESOURCE_CONFIG['hosts']
     assert training_env.channel_input_dirs['train'].endswith('/opt/ml/input/data/train')
     assert training_env.channel_input_dirs['validation'].endswith('/opt/ml/input/data/validation')
@@ -158,6 +158,7 @@ def test_train_env(training_env):
     assert training_env.module_dir == 'imagenet'
     assert training_env.enable_metrics
     assert training_env.log_level == logging.WARNING
+    assert training_env.network_interface_name == 'ethwe'
 
 
 def test_serving_env(serving_env):
@@ -175,8 +176,8 @@ def test_train_env_properties(training_env):
     assert training_env.properties() == ['channel_input_dirs', 'current_host', 'enable_metrics', 'framework_module',
                                          'hosts', 'hyperparameters', 'input_config_dir', 'input_data_config',
                                          'input_dir', 'log_level', 'model_dir', 'module_dir', 'module_name',
-                                         'num_cpus', 'num_gpus', 'output_data_dir', 'output_dir',
-                                         'resource_config']
+                                         'network_interface_name', 'num_cpus', 'num_gpus', 'output_data_dir',
+                                         'output_dir', 'resource_config']
 
 
 def test_serving_env_properties(serving_env):

--- a/test/unit/test_environment.py
+++ b/test/unit/test_environment.py
@@ -15,12 +15,14 @@ import json
 import logging
 import os
 
-from mock import Mock, patch
+from mock import Mock, mock_open, patch
 import pytest
 import six
 
 from sagemaker_containers import env
 import test
+
+builtins_open = '__builtin__.open' if six.PY2 else 'builtins.open'
 
 RESOURCE_CONFIG = dict(current_host='algo-1', hosts=['algo-1', 'algo-2', 'algo-3'])
 
@@ -230,3 +232,18 @@ def test_tmpdir_with_args(rmtree, mkdtemp):
     with env.tmpdir('suffix', 'prefix', '/tmp'):
         mkdtemp.assert_called_with(dir='/tmp', prefix='prefix', suffix='suffix')
     rmtree.assert_called()
+
+
+@patch(builtins_open, mock_open())
+def test_write_file():
+    env.write_file('/tmp/my-file', '42')
+
+    open.assert_called_with('/tmp/my-file', 'w')
+
+    open().write.assert_called_with('42')
+
+    env.write_file('/tmp/my-file', '42', 'x')
+
+    open.assert_called_with('/tmp/my-file', 'x')
+
+    open().write.assert_called_with('42')

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -51,7 +51,7 @@ def test_prepare():
     open.assert_any_call('c:/path/to/setup.cfg', 'w')
     open.assert_any_call('c:/path/to/MANIFEST.in', 'w')
 
-    content = textwrap.dedent("""
+    data = textwrap.dedent("""
     from setuptools import setup
 
     setup(packages=[''],
@@ -60,22 +60,22 @@ def test_prepare():
           include_package_data=True)
     """)
 
-    open().write.assert_any_call(content)
+    open().write.assert_any_call(data)
 
-    content = textwrap.dedent("""
+    data = textwrap.dedent("""
     [wheel]
     universal = 1
     """)
-    open().write.assert_any_call(content)
+    open().write.assert_any_call(data)
 
-    content = textwrap.dedent("""
+    data = textwrap.dedent("""
     recursive-include . *
 
     recursive-exclude . __pycache__*
     recursive-exclude . *.pyc
     recursive-exclude . *.pyo
     """)
-    open().write.assert_any_call(content)
+    open().write.assert_any_call(data)
 
 
 @patch(builtins_open, mock_open())

--- a/test/unit/test_transfomer.py
+++ b/test/unit/test_transfomer.py
@@ -13,7 +13,7 @@
 from mock import MagicMock, patch
 import pytest
 
-from sagemaker_containers import content_types, env, status_codes, transformer
+from sagemaker_containers import content_types, env, errors, status_codes, transformer
 import test
 
 
@@ -57,7 +57,7 @@ def fn_with_error(*args, **kwargs):
 
 
 def test_transformer_initialize_with_client_error():
-    with pytest.raises(transformer.ClientError) as e:
+    with pytest.raises(errors.ClientError) as e:
         transformer.Transformer(model_fn=fn_with_error).initialize()
 
     assert e.value.args[0] == error_from_fn
@@ -70,7 +70,7 @@ def test_transformer_initialize_with_client_error():
 ])
 @patch('sagemaker_containers.worker.Request', lambda: request)
 def test_transformer_transform_with_client_error(input_fn, predict_fn, output_fn):
-    with pytest.raises(transformer.ClientError) as e:
+    with pytest.raises(errors.ClientError) as e:
         transform = transformer.Transformer(model_fn=MagicMock(), input_fn=input_fn,
                                             predict_fn=predict_fn, output_fn=output_fn)
 

--- a/test/unit/test_transfomer.py
+++ b/test/unit/test_transfomer.py
@@ -41,7 +41,7 @@ def test_predict_fn():
         transformer.default_predict_fn('data', 'model')
 
 
-request = test.request(data='42')
+request = test.request(data='42', content_type=content_types.JSON)
 
 
 def test_transformer_initialize_with_default_model_fn():
@@ -102,7 +102,6 @@ def test_transformer_transform(response):
                                         predict_fn=predict_fn, output_fn=output_fn)
 
     transform.initialize()
-
     assert transform.transform() == response
 
     input_fn.assert_called_with(request.content, request.content_type)

--- a/test/unit/test_transfomer.py
+++ b/test/unit/test_transfomer.py
@@ -38,7 +38,7 @@ def test_default_model_fn():
 
 def test_predict_fn():
     with pytest.raises(NotImplementedError):
-        transformer.default_predict_fn('model', 'data')
+        transformer.default_predict_fn('data', 'model')
 
 
 request = test.request(data='42')
@@ -89,7 +89,7 @@ def test_initialize():
 
     transformer.Transformer(model_fn=model_fn).initialize()
 
-    model_fn.assert_called_with(model_dir=env.MODEL_PATH)
+    model_fn.assert_called_with(env.MODEL_PATH)
 
 
 @patch('sagemaker_containers.worker.Request', lambda: request)
@@ -105,9 +105,9 @@ def test_transformer_transform(response):
 
     assert transform.transform() == response
 
-    input_fn.assert_called_with(input_data=request.content, content_type=request.content_type)
-    predict_fn.assert_called_with(model=model_fn(), data=input_fn())
-    output_fn.assert_called_with(prediction=predict_fn(), accept=request.accept)
+    input_fn.assert_called_with(request.content, request.content_type)
+    predict_fn.assert_called_with(input_fn(), model_fn())
+    output_fn.assert_called_with(predict_fn(), request.accept)
 
 
 @patch('sagemaker_containers.worker.Request', lambda: request)
@@ -121,6 +121,6 @@ def test_transformer_transform_backwards_compatibility():
 
     assert transform.transform().status_code == status_codes.OK
 
-    input_fn.assert_called_with(input_data=request.content, content_type=request.content_type)
-    predict_fn.assert_called_with(model=model_fn(), data=input_fn())
-    output_fn.assert_called_with(prediction=predict_fn(), accept=request.accept)
+    input_fn.assert_called_with(request.content, request.content_type)
+    predict_fn.assert_called_with(input_fn(), model_fn())
+    output_fn.assert_called_with(predict_fn(), request.accept)

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -91,8 +91,8 @@ def test_request():
     assert request.content_type == content_types.NPY
     assert request.accept == content_types.CSV
 
-    result = encoders.decode(request.content, content_types.NPY)
-    np.testing.assert_array_equal(result, np.array([6, 9.3], dtype=np.float32))
+    result = encoders.decode(request.data, content_types.NPY)
+    np.testing.assert_array_equal(result, np.array([6, 9.3]))
 
 
 def test_request_content_type():

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -92,7 +92,7 @@ def test_request():
     assert request.accept == content_types.CSV
 
     result = encoders.decode(request.content, content_types.NPY)
-    np.testing.assert_array_equal(result, [6, 9.3])
+    np.testing.assert_array_equal(result, np.array([6, 9.3], dtype=np.float32))
 
 
 def test_request_content_type():


### PR DESCRIPTION
# Description of changes:

- add network_interface_name env parameter
- append current_host to output_data_dir
- revert parameters to predict_fn to match MXNet
- invoking transformation functions with positional arguments instead of named arguments
- unicode support
- passing dtype in the encoder functions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
