### PR TITLE
Make output_data_dir to be '/opt/ml/output/data' 

### DIFF
--- a/src/sagemaker_containers/_env.py
+++ b/src/sagemaker_containers/_env.py
@@ -443,7 +443,7 @@ class TrainingEnv(_Env):
         self._hyperparameters = split_result.excluded
         self._resource_config = resource_config
         self._input_data_config = input_data_config
-        self._output_data_dir = os.path.join(_output_data_dir, current_host)
+        self._output_data_dir = _output_data_dir
         self._channel_input_dirs = {channel: channel_path(channel) for channel in input_data_config}
         self._current_host = current_host
 

--- a/test/unit/test_environment.py
+++ b/test/unit/test_environment.py
@@ -179,7 +179,7 @@ def test_training_env(training_env):
     assert training_env.hyperparameters == USER_HYPERPARAMETERS
     assert training_env.resource_config == RESOURCE_CONFIG
     assert training_env.input_data_config == INPUT_DATA_CONFIG
-    assert training_env.output_data_dir.endswith('/opt/ml/output/data/algo-1')
+    assert training_env.output_data_dir.endswith('/opt/ml/output/data')
     assert training_env.hosts == RESOURCE_CONFIG['hosts']
     assert training_env.channel_input_dirs['train'].endswith('/opt/ml/input/data/train')
     assert training_env.channel_input_dirs['validation'].endswith('/opt/ml/input/data/validation')


### PR DESCRIPTION
Make output_data_dir to be '/opt/ml/output/data' instead of '/opt/ml/output/data/algo-1' since the latter doesn't exist.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
