### PR TITLE
Return 4XX status codes for errors raised during transform() 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,18 @@
 CHANGELOG
 =========
 
+2.2.0
+=====
+
+* [breaking change] Remove ``UnsupportedFormatError``
+* Add ``UnsupportedContentTypeError`` and ``UnsupportedAcceptTypeError``
+* Return 4XX status codes for errors raised during transform()
+
 2.1.0
 =====
+
 * Allow for local modules to work with AWS SageMaker framework containers.
 * Support for training outside of AWS SageMaker Training.
-
 
 2.0.4
 =====

--- a/src/sagemaker_containers/_encoders.py
+++ b/src/sagemaker_containers/_encoders.py
@@ -13,12 +13,11 @@
 from __future__ import absolute_import
 
 import json
-import textwrap
 
 import numpy as np
 from six import BytesIO, StringIO
 
-from sagemaker_containers import _content_types
+from sagemaker_containers import _content_types, _errors
 
 
 def array_to_npy(array_like):  # type: (np.array or Iterable or int or float) -> object
@@ -136,7 +135,7 @@ def decode(obj, content_type):  # type: (np.array or Iterable or int or float) -
         decoder = _decoders_map[content_type]
         return decoder(obj)
     except KeyError:
-        raise UnsupportedFormatError(content_type)
+        raise _errors.UnsupportedContentTypeError(content_type)
 
 
 def encode(array_like, content_type):  # type: (np.array or Iterable or int or float) -> np.array
@@ -156,15 +155,4 @@ def encode(array_like, content_type):  # type: (np.array or Iterable or int or f
         encoder = _encoders_map[content_type]
         return encoder(array_like)
     except KeyError:
-        raise UnsupportedFormatError(content_type)
-
-
-class UnsupportedFormatError(Exception):
-    def __init__(self, content_type, **kwargs):
-        super(Exception, self).__init__(**kwargs)
-        self.message = textwrap.dedent(
-            """Content type %s is not supported by this framework.
-
-               Please implement input_fn to to deserialize the request data or an output_fn to serialize the
-               response. For more information: https://github.com/aws/sagemaker-python-sdk#input-processing"""
-            % content_type)
+        raise _errors.UnsupportedAcceptTypeError(content_type)

--- a/src/sagemaker_containers/_errors.py
+++ b/src/sagemaker_containers/_errors.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import textwrap
+
 import six
 
 
@@ -54,3 +56,25 @@ class ExecuteUserScriptError(_CalledProcessError):
 class ChannelDoesNotExistException(Exception):
     def __init__(self, channel_name):
         super(ChannelDoesNotExistException, self).__init__('Channel %s is not a valid channel' % channel_name)
+
+
+class UnsupportedContentTypeError(Exception):
+    def __init__(self, content_type, **kwargs):
+        super(Exception, self).__init__(**kwargs)
+        self.message = textwrap.dedent(
+            """Content type %s is not supported by this framework.
+
+            Please implement input_fn to to deserialize the request data.
+            For more, see the SageMaker Python SDK README."""
+            % content_type)
+
+
+class UnsupportedAcceptTypeError(Exception):
+    def __init__(self, content_type, **kwargs):
+        super(Exception, self).__init__(**kwargs)
+        self.message = textwrap.dedent(
+            """Content type %s is not supported by this framework.
+
+            Please implement output_fn to serialize the response.
+            For more, see the SageMaker Python SDK README."""
+            % content_type)

--- a/src/sagemaker_containers/_status_codes.py
+++ b/src/sagemaker_containers/_status_codes.py
@@ -12,3 +12,7 @@
 # language governing permissions and limitations under the License.
 OK = 200
 ACCEPTED = 202
+
+BAD_REQUEST = 400
+NOT_ACCEPTABLE = 406
+UNSUPPORTED_MEDIA_TYPE = 415

--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 from six import BytesIO
 
-from sagemaker_containers import _content_types, _encoders
+from sagemaker_containers import _content_types, _encoders, _errors
 
 
 @pytest.mark.parametrize('target', ([42, 6, 9], [42., 6., 9.], ['42', '6', '9'], [u'42', u'6', u'9'], {42: {'6': 9.}}))
@@ -110,12 +110,12 @@ def test_encode(content_type):
 
 
 def test_encode_error():
-    with pytest.raises(_encoders.UnsupportedFormatError):
+    with pytest.raises(_errors.UnsupportedAcceptTypeError):
         _encoders.encode(42, _content_types.OCTET_STREAM)
 
 
 def test_decode_error():
-    with pytest.raises(_encoders.UnsupportedFormatError):
+    with pytest.raises(_errors.UnsupportedContentTypeError):
         _encoders.decode(42, _content_types.OCTET_STREAM)
 
 


### PR DESCRIPTION
This adds error-handling in `Transformer.transform()` to take any errors raised during the invocation of `input_fn()`, `predict_fn()`, and `transform_fn()` and return 4XX status codes.

A few notes:
* open to suggestions on how to better document the breaking change in the changelog
* I do want to look into finding a module for the HTTP status codes that's compatible with both Python 2 and 3 so that we're not just redundantly defining them on our own
* I might submit a separate PR to add more information in the returned response

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
