### PR TITLE
Add error info to 4XX response body

### DIFF
--- a/src/sagemaker_containers/_encoders.py
+++ b/src/sagemaker_containers/_encoders.py
@@ -161,10 +161,10 @@ def encode(array_like, content_type):  # type: (np.array or Iterable or int or f
 
 class UnsupportedFormatError(Exception):
     def __init__(self, content_type, **kwargs):
-        super(Exception, self).__init__(**kwargs)
         self.message = textwrap.dedent(
             """Content type %s is not supported by this framework.
 
-               Please implement input_fn to to deserialize the request data or an output_fn to serialize the
-               response. For more information: https://github.com/aws/sagemaker-python-sdk#input-processing"""
+            Please implement input_fn to to deserialize the request data or an output_fn to
+            serialize the response. For more information, see the SageMaker Python SDK README."""
             % content_type)
+        super(Exception, self).__init__(self.message, **kwargs)

--- a/src/sagemaker_containers/_transformer.py
+++ b/src/sagemaker_containers/_transformer.py
@@ -175,5 +175,5 @@ class Transformer(object):
     def _error_response(self, error, status_code):
         body = json.dumps({'error': error.__class__.__name__,
                            'error-message': str(error),
-                           'stack-trace': traceback.format_tb(error.__traceback__)})
+                           'stack-trace': traceback.format_exc()})
         return _worker.Response(response=body, status=status_code)

--- a/src/sagemaker_containers/_transformer.py
+++ b/src/sagemaker_containers/_transformer.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import json
 import textwrap
+import traceback
 
 from six.moves import http_client
 
@@ -172,5 +173,7 @@ class Transformer(object):
         return result
 
     def _error_response(self, error, status_code):
-        body = json.dumps({'error': str(error)})
+        body = json.dumps({'error': error.__class__.__name__,
+                           'error-message': str(error),
+                           'stack-trace': traceback.format_tb(error.__traceback__)})
         return _worker.Response(response=body, status=status_code)

--- a/test/unit/test_transfomer.py
+++ b/test/unit/test_transfomer.py
@@ -10,6 +10,8 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import json
+
 from mock import MagicMock, patch
 import pytest
 from six.moves import http_client
@@ -85,6 +87,10 @@ def test_transformer_transform_with_unsupported_content_type():
 
     assert response.status_code == http_client.UNSUPPORTED_MEDIA_TYPE
 
+    response_body = json.loads(response.response[0].decode('utf-8'))
+    assert response_body['error'] == 'UnsupportedFormatError'
+    assert bad_request.content_type in response_body['error-message']
+
 
 def test_transformer_transform_with_unsupported_accept_type():
     def empty_fn(*args):
@@ -96,6 +102,10 @@ def test_transformer_transform_with_unsupported_accept_type():
         response = t.transform()
 
     assert response.status_code == http_client.NOT_ACCEPTABLE
+
+    response_body = json.loads(response.response[0].decode('utf-8'))
+    assert response_body['error'] == 'UnsupportedFormatError'
+    assert bad_request.accept in response_body['error-message']
 
 
 @patch('sagemaker_containers._worker.Request', lambda: request)


### PR DESCRIPTION
*Description of changes:*
This change adds the error message and stack trace to the response body when the server returns a 4XX status code.

Additionally, I made a couple tweaks to `_encoders.UnsupportedFormatError`:
1. remove the dead link from the error message. currently, some of the framework READMEs have "input processing" sections, but there is no general one. Also, as this error is used for both input and output processing, it's weird to link to one but not the other.
1. include the error message in the `super()` call. This way, one can get the error message by invoking `str()`, as one would with any other Python exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
