### PR TITLE
Move UnsupportedFormatError from encoders to errors module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ CHANGELOG
 =====
 
 * [breaking change] Remove ``status_codes`` module and use ``six.moves.http_client`` instead
+* [breaking change] Move ``UnsupportedFormatError`` from ``encoders`` module to ``errors`` module
 * Return 4XX status codes for ``UnsupportedFormatError`` from default input/output handlers
 
 2.1.0

--- a/src/sagemaker_containers/_encoders.py
+++ b/src/sagemaker_containers/_encoders.py
@@ -13,12 +13,11 @@
 from __future__ import absolute_import
 
 import json
-import textwrap
 
 import numpy as np
 from six import BytesIO, StringIO
 
-from sagemaker_containers import _content_types
+from sagemaker_containers import _content_types, _errors
 
 
 def array_to_npy(array_like):  # type: (np.array or Iterable or int or float) -> object
@@ -136,7 +135,7 @@ def decode(obj, content_type):  # type: (np.array or Iterable or int or float) -
         decoder = _decoders_map[content_type]
         return decoder(obj)
     except KeyError:
-        raise UnsupportedFormatError(content_type)
+        raise _errors.UnsupportedFormatError(content_type)
 
 
 def encode(array_like, content_type):  # type: (np.array or Iterable or int or float) -> np.array
@@ -156,15 +155,4 @@ def encode(array_like, content_type):  # type: (np.array or Iterable or int or f
         encoder = _encoders_map[content_type]
         return encoder(array_like)
     except KeyError:
-        raise UnsupportedFormatError(content_type)
-
-
-class UnsupportedFormatError(Exception):
-    def __init__(self, content_type, **kwargs):
-        self.message = textwrap.dedent(
-            """Content type %s is not supported by this framework.
-
-            Please implement input_fn to to deserialize the request data or an output_fn to
-            serialize the response. For more information, see the SageMaker Python SDK README."""
-            % content_type)
-        super(Exception, self).__init__(self.message, **kwargs)
+        raise _errors.UnsupportedFormatError(content_type)

--- a/src/sagemaker_containers/_errors.py
+++ b/src/sagemaker_containers/_errors.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import textwrap
+
 import six
 
 
@@ -54,3 +56,14 @@ class ExecuteUserScriptError(_CalledProcessError):
 class ChannelDoesNotExistException(Exception):
     def __init__(self, channel_name):
         super(ChannelDoesNotExistException, self).__init__('Channel %s is not a valid channel' % channel_name)
+
+
+class UnsupportedFormatError(Exception):
+    def __init__(self, content_type, **kwargs):
+        self.message = textwrap.dedent(
+            """Content type %s is not supported by this framework.
+
+            Please implement input_fn to to deserialize the request data or an output_fn to
+            serialize the response. For more information, see the SageMaker Python SDK README."""
+            % content_type)
+        super(Exception, self).__init__(self.message, **kwargs)

--- a/src/sagemaker_containers/_transformer.py
+++ b/src/sagemaker_containers/_transformer.py
@@ -156,14 +156,14 @@ class Transformer(object):
 
         try:
             data = self._input_fn(request.content, request.content_type)
-        except _encoders.UnsupportedFormatError as e:
+        except _errors.UnsupportedFormatError as e:
             return self._error_response(e, http_client.UNSUPPORTED_MEDIA_TYPE)
 
         prediction = self._predict_fn(data, self._model)
 
         try:
             result = self._output_fn(prediction, request.accept)
-        except _encoders.UnsupportedFormatError as e:
+        except _errors.UnsupportedFormatError as e:
             return self._error_response(e, http_client.NOT_ACCEPTABLE)
 
         if isinstance(result, tuple):

--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 from six import BytesIO
 
-from sagemaker_containers import _content_types, _encoders
+from sagemaker_containers import _content_types, _encoders, _errors
 
 
 @pytest.mark.parametrize('target', ([42, 6, 9], [42., 6., 9.], ['42', '6', '9'], [u'42', u'6', u'9'], {42: {'6': 9.}}))
@@ -110,12 +110,12 @@ def test_encode(content_type):
 
 
 def test_encode_error():
-    with pytest.raises(_encoders.UnsupportedFormatError):
+    with pytest.raises(_errors.UnsupportedFormatError):
         _encoders.encode(42, _content_types.OCTET_STREAM)
 
 
 def test_decode_error():
-    with pytest.raises(_encoders.UnsupportedFormatError):
+    with pytest.raises(_errors.UnsupportedFormatError):
         _encoders.decode(42, _content_types.OCTET_STREAM)
 
 


### PR DESCRIPTION
This is a breaking change for how to import the UnsupportedFormatError class, but it makes more sense logically to have all the error classes defined in the errors module.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
