### PR TITLE
Fix choosing region for S3 client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+2.2.2
+=====
+
+* bug-fix: Fix choosing region for S3 client
+
 2.2.1
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ packages.append('sagemaker_containers.etc')
 
 setup(
     name='sagemaker_containers',
-    version='2.2.1',
+    version='2.2.2',
     description='Open source library for creating containers to run on Amazon SageMaker.',
 
     packages=packages,

--- a/src/sagemaker_containers/_modules.py
+++ b/src/sagemaker_containers/_modules.py
@@ -24,7 +24,7 @@ import boto3
 import six
 from six.moves.urllib.parse import urlparse
 
-from sagemaker_containers import _errors, _files, _logging
+from sagemaker_containers import _errors, _files, _logging, _params
 
 logger = _logging.get_logger()
 
@@ -45,7 +45,9 @@ def s3_download(url, dst):  # type: (str, str) -> None
 
     bucket, key = url.netloc, url.path.lstrip('/')
 
-    s3 = boto3.resource('s3', region_name=os.environ.get('AWS_REGION'))
+    region = os.environ.get('AWS_REGION', os.environ.get(_params.REGION_NAME_ENV))
+    s3 = boto3.resource('s3', region_name=region)
+
     s3.Bucket(bucket).download_file(key, dst)
 
 

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -23,7 +23,7 @@ from mock import call, mock_open, patch
 import pytest
 from six import PY2
 
-from sagemaker_containers import _errors, _modules
+from sagemaker_containers import _errors, _modules, _params
 import test
 
 builtins_open = '__builtin__.open' if PY2 else 'builtins.open'
@@ -34,9 +34,12 @@ builtins_open = '__builtin__.open' if PY2 else 'builtins.open'
                          [('S3://my-bucket/path/to/my-file', 'my-bucket', 'path/to/my-file', '/tmp/my-file'),
                           ('s3://my-bucket/my-file', 'my-bucket', 'my-file', '/tmp/my-file')])
 def test_s3_download(resource, url, bucket_name, key, dst):
+    region = 'us-west-2'
+    os.environ[_params.REGION_NAME_ENV] = region
+
     _modules.s3_download(url, dst)
 
-    chain = call('s3', region_name=os.environ.get('AWS_REGION')).Bucket(bucket_name).download_file(key, dst)
+    chain = call('s3', region_name=region).Bucket(bucket_name).download_file(key, dst)
     assert resource.mock_calls == chain.call_list()
 
 


### PR DESCRIPTION
*Description of changes:*
SageMaker Hosting doesn't set `AWS_REGION` (yet), so adding a fallback to use `SAGEMAKER_REGION`. Keeping both because it seems like @yangaws worked out with Training and Hosting that we should all use `AWS_REGION` in the future.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
