### PR TITLE
Stream stderr instead of capturing it when running training script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+2.2.7
+=====
+* feature: Making pip install less noisy
+* bug-fix: Stream stderr instead of capturing it when running user script
+
 2.2.6
 =====
 

--- a/src/sagemaker_containers/_errors.py
+++ b/src/sagemaker_containers/_errors.py
@@ -14,8 +14,6 @@ from __future__ import absolute_import
 
 import textwrap
 
-import six
-
 
 class ClientError(Exception):
     pass
@@ -29,15 +27,12 @@ class _CalledProcessError(ClientError):
       cmd, return_code, output
     """
 
-    def __init__(self, cmd, return_code=None, output=None):
+    def __init__(self, cmd, return_code=None):
         self.return_code = return_code
         self.cmd = cmd
-        self.output = output
 
     def __str__(self):
-        # transforms a byte string (b'') in unicode
-        error = self.output.decode('latin1') if six.PY3 else self.output
-        message = '%s:\nCommand "%s"\n%s' % (type(self).__name__, self.cmd, error)
+        message = '%s:\nCommand "%s"' % (type(self).__name__, self.cmd)
         return message.strip()
 
 

--- a/src/sagemaker_containers/_modules.py
+++ b/src/sagemaker_containers/_modules.py
@@ -229,21 +229,21 @@ def run(module_name, args=None, env_vars=None, wait=True):  # type: (str, list, 
 
     if wait:
         return _check_error(cmd, _errors.ExecuteUserScriptError)
+
     else:
         return _make_process(cmd)
 
 
 def _make_process(cmd, **kwargs):
-    return subprocess.Popen(cmd, stderr=subprocess.PIPE, env=os.environ, **kwargs)
+    return subprocess.Popen(cmd, env=os.environ, **kwargs)
 
 
 def _check_error(cmd, error_class, **kwargs):
     process = _make_process(cmd, **kwargs)
-    stdout, stderr = process.communicate()
+    return_code = process.wait()
 
-    return_code = process.poll()
     if return_code:
-        raise error_class(return_code=return_code, cmd=' '.join(cmd), output=stderr)
+        raise error_class(return_code=return_code, cmd=' '.join(cmd))
     return process
 
 

--- a/test/functional/test_training_framework.py
+++ b/test/functional/test_training_framework.py
@@ -322,7 +322,6 @@ def test_script_mode_client_error():
 
     message = str(e.value)
     assert 'ExecuteUserScriptError' in message
-    assert 'ZeroDivisionError' in message
 
 
 def test_script_mode_client_import_error():
@@ -342,8 +341,6 @@ def test_script_mode_client_import_error():
 
     message = str(e.value)
     assert 'InstallModuleError:' in message
-    assert "Invalid requirement: \'42/0\'" in message
-    assert "It looks like a path. File \'42/0\' does not exist." in message
 
 
 def failure_message():

--- a/test/unit/test_errors.py
+++ b/test/unit/test_errors.py
@@ -16,16 +16,12 @@ from sagemaker_containers import _errors
 
 
 def test_install_module_error():
-    error = _errors.InstallModuleError(['python', '-m', '42'], return_code=42, output=b'42')
+    error = _errors.InstallModuleError(['python', '-m', '42'], return_code=42)
 
-    assert str(error) == """InstallModuleError:
-Command "['python', '-m', '42']"
-42"""
+    assert str(error) == 'InstallModuleError:\nCommand "[\'python\', \'-m\', \'42\']"'
 
 
 def test_execute_user_script_error():
-    error = _errors.ExecuteUserScriptError(['python', '-m', '42'], return_code=42, output=b'42')
+    error = _errors.ExecuteUserScriptError(['python', '-m', '42'], return_code=42)
 
-    assert str(error) == """ExecuteUserScriptError:
-Command "['python', '-m', '42']"
-42"""
+    assert str(error) == 'ExecuteUserScriptError:\nCommand "[\'python\', \'-m\', \'42\']"'

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -140,7 +140,6 @@ def test_run_error():
 
     message = str(e.value)
     assert 'ExecuteUserScriptError:' in message
-    assert ' No module named wrong module' in message
 
 
 def test_python_executable_exception():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
TensorFlow logs to stderr when training is being executed outside of notebook. Currently users won't see any output from TensorFlow in their training log. This change stream out stderr instead of capturing it. Also subprocess.communicate() caches the bytes in memory with long running training jobs the buffer is in danger of overflowing. This change mitigate this risk as well.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
