### PR TITLE
Add bash support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,20 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
 from glob import glob
 import os
+import sys
 
 from setuptools import find_packages, setup
 
@@ -10,6 +25,12 @@ def read(file_name):
 
 packages = find_packages(where='src', exclude=('test',))
 packages.append('sagemaker_containers.etc')
+
+required_packages = ['boto3', 'six', 'pip', 'flask', 'gunicorn', 'gevent', 'werkzeug']
+
+# enum is introduced in Python 3.4. Installing enum back port
+if sys.version_info < (3, 4):
+    required_packages.append('enum34 >= 1.1.6')
 
 setup(
     name='sagemaker_containers',
@@ -37,7 +58,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires=['boto3', 'six', 'pip', 'flask', 'gunicorn', 'gevent', 'werkzeug'],
+    install_requires=required_packages,
 
     extras_require={
         'test': ['tox', 'flake8', 'pytest', 'pytest-cov', 'mock', 'sagemaker', 'numpy']

--- a/src/sagemaker_containers/__init__.py
+++ b/src/sagemaker_containers/__init__.py
@@ -13,7 +13,7 @@
 from __future__ import absolute_import
 
 
-def training_env():
+def training_env():  # type: () -> _env.TrainingEnv
     """Create a TrainingEnv.
 
     Returns:

--- a/src/sagemaker_containers/_env.py
+++ b/src/sagemaker_containers/_env.py
@@ -20,6 +20,7 @@ import os
 import shlex
 import socket
 import subprocess
+import sys
 import time
 
 import boto3
@@ -160,6 +161,15 @@ def _create_training_directories():
 
 if not _is_path_configured:
     _create_training_directories()
+
+
+def _create_code_dir():  # type: () -> None
+    """Creates /opt/ml/code when the module is imported."""
+    if not os.path.exists(code_dir):
+        os.makedirs(code_dir)
+
+
+_create_code_dir()
 
 
 def _read_json(path):  # type: (str) -> dict
@@ -310,6 +320,7 @@ class _Env(_mapping.MappingMixin):
         self._num_gpus = num_gpus()
         self._num_cpus = num_cpus()
         self._module_name = module_name
+        self._user_entry_point = module_name
         self._module_dir = module_dir
         self._log_level = log_level
         self._model_dir = model_dir
@@ -367,6 +378,14 @@ class _Env(_mapping.MappingMixin):
             int: environment logging level.
         """
         return self._log_level
+
+    @property
+    def user_entry_point(self):  # type: () -> str
+        """The name of provided user entrypoint.
+        Returns:
+            str: The name of provided user entrypoint
+        """
+        return self._user_entry_point
 
     @staticmethod
     def _parse_module_name(program_param):
@@ -537,6 +556,8 @@ class TrainingEnv(_Env):
         # override base class attributes
         if self._module_name is None:
             self._module_name = str(sagemaker_hyperparameters.get(_params.USER_PROGRAM_PARAM, None))
+        self._user_entry_point = self._user_entry_point or sagemaker_hyperparameters.get(_params.USER_PROGRAM_PARAM)
+
         self._module_dir = str(sagemaker_hyperparameters.get(_params.SUBMIT_DIR_PARAM, code_dir))
         self._log_level = sagemaker_hyperparameters.get(_params.LOG_LEVEL_PARAM, logging.INFO)
         self._framework_module = os.environ.get(_params.FRAMEWORK_TRAINING_MODULE_ENV, None)
@@ -584,7 +605,7 @@ class TrainingEnv(_Env):
 
         env = {
             'hosts':            self.hosts, 'network_interface_name': self.network_interface_name,
-            'hps':              self.hyperparameters,
+            'hps':              self.hyperparameters, 'user_entry_point': self.user_entry_point,
             'framework_params': self.additional_framework_parameters,
             'resource_config':  self.resource_config, 'input_data_config': self.input_data_config,
             'output_data_dir':  self.output_data_dir, 'channels': sorted(self.channel_input_dirs.keys()),
@@ -842,3 +863,19 @@ class ServingEnv(_Env):
             str: HTTP port range that can be used by customers to avoid collisions with the HTTP port
                 specified by SageMaker for handling pings and invocations. For example: 1111-2222"""
         return self._safe_port_range
+
+
+def write_env_vars(env_vars=None):  # type: (dict) -> None
+    """Write the dictionary env_vars in the system, as environment variables.
+
+    Args:
+        env_vars ():
+
+    Returns:
+
+    """
+    env_vars = env_vars or {}
+    env_vars['PYTHONPATH'] = ':'.join(sys.path)
+
+    for name, value in env_vars.items():
+        os.environ[name] = value

--- a/src/sagemaker_containers/_modules.py
+++ b/src/sagemaker_containers/_modules.py
@@ -15,105 +15,16 @@ from __future__ import absolute_import
 import importlib
 import os
 import shlex
-import subprocess
 import sys
-import tarfile
-import textwrap
+import warnings
 
-import boto3
 import six
-from six.moves.urllib.parse import urlparse
 
-from sagemaker_containers import _errors, _files, _logging, _params
+from sagemaker_containers import _env, _errors, _files, _logging, _process
 
 logger = _logging.get_logger()
 
 DEFAULT_MODULE_NAME = 'default_user_module_name'
-
-
-def s3_download(url, dst):  # type: (str, str) -> None
-    """Download a file from S3.
-
-    Args:
-        url (str): the s3 url of the file.
-        dst (str): the destination where the file will be saved.
-    """
-    url = urlparse(url)
-
-    if url.scheme != 's3':
-        raise ValueError("Expecting 's3' scheme, got: %s in %s" % (url.scheme, url))
-
-    bucket, key = url.netloc, url.path.lstrip('/')
-
-    region = os.environ.get('AWS_REGION', os.environ.get(_params.REGION_NAME_ENV))
-    s3 = boto3.resource('s3', region_name=region)
-
-    s3.Bucket(bucket).download_file(key, dst)
-
-
-def prepare(path, name):  # type: (str, str) -> None
-    """Prepare a Python script (or module) to be imported as a module.
-
-    If the script does not contain a setup.py file, it creates a minimal setup.
-
-    Args:
-        path (str): path to directory with the script or module.
-        name (str): name of the script or module.
-    """
-    setup_path = os.path.join(path, 'setup.py')
-    if not os.path.exists(setup_path):
-        data = textwrap.dedent("""
-        from setuptools import setup
-
-        setup(packages=[''],
-              name="%s",
-              version='1.0.0',
-              include_package_data=True)
-        """ % name)
-
-        logger.info('Module %s does not provide a setup.py. \nGenerating setup.py' % name)
-
-        _files.write_file(setup_path, data)
-
-        data = textwrap.dedent("""
-        [wheel]
-        universal = 1
-        """)
-
-        logger.info('Generating setup.cfg')
-
-        _files.write_file(os.path.join(path, 'setup.cfg'), data)
-
-        data = textwrap.dedent("""
-        recursive-include . *
-
-        recursive-exclude . __pycache__*
-        recursive-exclude . *.pyc
-        recursive-exclude . *.pyo
-        """)
-
-        logger.info('Generating MANIFEST.in')
-
-        _files.write_file(os.path.join(path, 'MANIFEST.in'), data)
-
-
-def install(path):  # type: (str) -> None
-    """Install a Python module in the executing Python environment.
-
-    Args:
-        path (str):  Real path location of the Python module.
-    """
-    if not sys.executable:
-        raise RuntimeError('Failed to retrieve the real path for the Python executable binary')
-
-    cmd = '%s -m pip install -U . ' % python_executable()
-
-    if os.path.exists(os.path.join(path, 'requirements.txt')):
-        cmd += '-r requirements.txt'
-
-    logger.info('Installing module with the following command:\n%s', cmd)
-
-    _check_error(shlex.split(cmd), _errors.InstallModuleError, cwd=path)
 
 
 def exists(name):  # type: (str) -> bool
@@ -133,42 +44,23 @@ def exists(name):  # type: (str) -> bool
         return True
 
 
-def download_and_install(uri, name=DEFAULT_MODULE_NAME, cache=True):
-    # type: (str, str, bool) -> module
-    """Download, prepare and install a compressed tar file from S3 or local directory as a module.
+def has_requirements(path):  # type: (str) -> None
+    return os.path.exists(os.path.join(path, 'requirements.txt'))
 
-    SageMaker Python SDK saves the user provided scripts as compressed tar files in S3
-    https://github.com/aws/sagemaker-python-sdk.
 
-    This function downloads this compressed file, if provided, and transforms it as a module, and installs it.
-
+def install(path):  # type: (str) -> None
+    """Install a Python module in the executing Python environment.
     Args:
-        name (str): name of the script or module.
-        uri (str): the location of the module.
-        cache (bool): default True. It will not download and install the module again if it is already installed.
-
-    Returns:
-        (module): the imported module
+        path (str):  Real path location of the Python module.
     """
-    should_use_cache = cache and exists(name)
+    cmd = '%s -m pip install -U . ' % _process.python_executable()
 
-    if not should_use_cache:
-        with _files.tmpdir() as tmpdir:
-            if uri.startswith('s3://'):
-                dst = os.path.join(tmpdir, 'tar_file')
-                s3_download(uri, dst)
-                module_path = os.path.join(tmpdir, 'module_dir')
-                os.makedirs(module_path)
+    if has_requirements(path):
+        cmd += '-r requirements.txt'
 
-                with tarfile.open(name=dst, mode='r:gz') as t:
-                    t.extractall(path=module_path)
+    logger.info('Installing module with the following command:\n%s', cmd)
 
-            else:
-                module_path = uri
-
-            prepare(module_path, name)
-
-            install(module_path)
+    _process.check_error(shlex.split(cmd), _errors.InstallModuleError, cwd=path)
 
 
 def run(module_name, args=None, env_vars=None, wait=True):  # type: (str, list, dict, bool) -> Popen
@@ -223,42 +115,18 @@ def run(module_name, args=None, env_vars=None, wait=True):  # type: (str, list, 
     args = args or []
     env_vars = env_vars or {}
 
-    cmd = [python_executable(), '-m', module_name] + args
+    cmd = [_process.python_executable(), '-m', module_name] + args
 
     _logging.log_script_invocation(cmd, env_vars)
 
     if wait:
-        return _check_error(cmd, _errors.ExecuteUserScriptError)
+        return _process.check_error(cmd, _errors.ExecuteUserScriptError)
 
     else:
-        return _make_process(cmd)
+        return _process.create(cmd, _errors.ExecuteUserScriptError)
 
 
-def _make_process(cmd, **kwargs):
-    return subprocess.Popen(cmd, env=os.environ, **kwargs)
-
-
-def _check_error(cmd, error_class, **kwargs):
-    process = _make_process(cmd, **kwargs)
-    return_code = process.wait()
-
-    if return_code:
-        raise error_class(return_code=return_code, cmd=' '.join(cmd))
-    return process
-
-
-def python_executable():
-    """Returns the real path for the Python executable, if it exists. Returns RuntimeError otherwise.
-
-    Returns:
-        (str): the real path of the current Python executable
-    """
-    if not sys.executable:
-        raise RuntimeError('Failed to retrieve the real path for the Python executable binary')
-    return sys.executable
-
-
-def import_module(uri, name=DEFAULT_MODULE_NAME, cache=True):  # type: (str, str, bool) -> module
+def import_module(uri, name=DEFAULT_MODULE_NAME, cache=None):  # type: (str, str, bool) -> module
     """Download, prepare and install a compressed tar file from S3 or provided directory as a module.
     SageMaker Python SDK saves the user provided scripts as compressed tar files in S3
     https://github.com/aws/sagemaker-python-sdk.
@@ -270,8 +138,10 @@ def import_module(uri, name=DEFAULT_MODULE_NAME, cache=True):  # type: (str, str
     Returns:
         (module): the imported module
     """
-    download_and_install(uri, name, cache)
+    _warning_cache_deprecation(cache)
+    _files.download_and_extract(uri, name, _env.code_dir)
 
+    install(_env.code_dir)
     try:
         module = importlib.import_module(name)
         six.moves.reload_module(module)
@@ -281,7 +151,7 @@ def import_module(uri, name=DEFAULT_MODULE_NAME, cache=True):  # type: (str, str
         six.reraise(_errors.ImportModuleError, _errors.ImportModuleError(e), sys.exc_info()[2])
 
 
-def run_module(uri, args, env_vars=None, name=DEFAULT_MODULE_NAME, cache=True, wait=True):
+def run_module(uri, args, env_vars=None, name=DEFAULT_MODULE_NAME, cache=None, wait=True):
     # type: (str, list, dict, str, bool, bool) -> Popen
     """Download, prepare and executes a compressed tar file from S3 or provided directory as a module.
 
@@ -297,26 +167,20 @@ def run_module(uri, args, env_vars=None, name=DEFAULT_MODULE_NAME, cache=True, w
         wait (bool): If True run_module will wait for the user module to exit and check the exit code,
                      otherwise it will launch the user module with subprocess and return the process object.
     """
+    _warning_cache_deprecation(cache)
     env_vars = env_vars or {}
     env_vars = env_vars.copy()
 
-    download_and_install(uri, name, cache)
+    _files.download_and_extract(uri, name, _env.code_dir)
 
-    write_env_vars(env_vars)
+    install(_env.code_dir)
+
+    _env.write_env_vars(env_vars)
 
     return run(name, args, env_vars, wait)
 
 
-def write_env_vars(env_vars=None):  # type: (dict) -> None
-    """Write the dictionary env_vars in the system, as environment variables.
-
-    Args:
-        env_vars ():
-
-    Returns:
-
-    """
-    env_vars = env_vars or {}
-
-    for name, value in env_vars.items():
-        os.environ[name] = value
+def _warning_cache_deprecation(cache):
+    if cache is not None:
+        msg = 'the cache parameter is unnecessary anymore. Cache is always set to True'
+        warnings.warn(msg, DeprecationWarning)

--- a/src/sagemaker_containers/_process.py
+++ b/src/sagemaker_containers/_process.py
@@ -1,0 +1,48 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import os
+import subprocess
+import sys
+
+import six
+
+from sagemaker_containers.beta.framework import env
+
+
+def create(cmd, error_class, cwd=None, **kwargs):
+    try:
+        return subprocess.Popen(cmd, env=os.environ, cwd=cwd or env.code_dir, **kwargs)
+    except Exception as e:
+        six.reraise(error_class, error_class(e), sys.exc_info()[2])
+
+
+def check_error(cmd, error_class, **kwargs):
+    process = create(cmd, error_class, **kwargs)
+    return_code = process.wait()
+
+    if return_code:
+        raise error_class(return_code=return_code, cmd=' '.join(cmd))
+    return process
+
+
+def python_executable():
+    """Returns the real path for the Python executable, if it exists. Returns RuntimeError otherwise.
+
+    Returns:
+        (str): the real path of the current Python executable
+    """
+    if not sys.executable:
+        raise RuntimeError('Failed to retrieve the real path for the Python executable binary')
+    return sys.executable

--- a/src/sagemaker_containers/_trainer.py
+++ b/src/sagemaker_containers/_trainer.py
@@ -15,9 +15,9 @@ import os
 import traceback
 
 import sagemaker_containers
-from sagemaker_containers import _errors, _files, _logging
+from sagemaker_containers.beta.framework import entrypoint, errors, files, logging
 
-logger = _logging.get_logger()
+logger = logging.get_logger()
 
 SUCCESS_CODE = 0
 DEFAULT_FAILURE_CODE = 1
@@ -42,35 +42,37 @@ def train():
         # if the framework module is not defined.
         env = sagemaker_containers.training_env()
 
-        framework_name, entry_point_name = env.framework_module.split(':')
+        if env.framework_module:
+            framework_name, entry_point_name = env.framework_module.split(':')
 
-        framework = importlib.import_module(framework_name)
+            framework = importlib.import_module(framework_name)
 
-        # the logger is configured after importing the framework library, allowing the framework to
-        # configure logging at import time.
-        _logging.configure_logger(env.log_level)
+            # the logger is configured after importing the framework library, allowing the framework to
+            # configure logging at import time.
+            logging.configure_logger(env.log_level)
+            logger.info('Imported framework %s', framework_name)
 
-        logger.info('Imported framework %s', framework_name)
-
-        entry_point = getattr(framework, entry_point_name)
-
-        entry_point()
+            entry_point = getattr(framework, entry_point_name)
+            entry_point()
+        else:
+            logging.configure_logger(env.log_level)
+            entrypoint.run(env.module_dir, env.user_entry_point, env.to_cmd_args(), env.to_env_vars())
 
         logger.info('Reporting training SUCCESS')
-        _files.write_success_file()
+        files.write_success_file()
         _exit_processes(SUCCESS_CODE)
 
-    except _errors.ClientError as e:
+    except errors.ClientError as e:
 
         failure_message = str(e)
-        _files.write_failure_file(failure_message)
+        files.write_failure_file(failure_message)
 
         logger.error(failure_message)
         _exit_processes(DEFAULT_FAILURE_CODE)
     except Exception as e:
         failure_msg = 'framework error: \n%s\n%s' % (traceback.format_exc(), str(e))
 
-        _files.write_failure_file(failure_msg)
+        files.write_failure_file(failure_msg)
         logger.error('Reporting training FAILURE')
 
         logger.error(failure_msg)

--- a/src/sagemaker_containers/beta/framework/__init__.py
+++ b/src/sagemaker_containers/beta/framework/__init__.py
@@ -19,15 +19,19 @@ from sagemaker_containers import _content_types as content_types
 from sagemaker_containers import _encoders as encoders
 from sagemaker_containers import _errors as errors
 from sagemaker_containers import _env as env
+from sagemaker_containers import entrypoint
+from sagemaker_containers import _files as files
 from sagemaker_containers import _functions as functions
 from sagemaker_containers import _logging as logging
 from sagemaker_containers import _mapping as mapping
 from sagemaker_containers import _modules as modules
 from sagemaker_containers import _params as params
+from sagemaker_containers import  _process as process
 from sagemaker_containers import _server as server
 from sagemaker_containers import _trainer as trainer
 from sagemaker_containers import _transformer as transformer
 from sagemaker_containers import _worker as worker
+
 
 def training_env(resource_config=None, input_data_config=None, hyperparameters=None):
 

--- a/src/sagemaker_containers/entrypoint.py
+++ b/src/sagemaker_containers/entrypoint.py
@@ -1,0 +1,169 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import enum
+import os
+import sys
+
+from sagemaker_containers import _env, _errors, _files, _logging, _modules, _process
+
+
+def run(uri, user_entry_point, args, env_vars=None, wait=True):
+    # type: (str, str, list, dict, bool) -> subprocess.Popen
+    """Runs the user entry-point, passing env_vars as environment variables and args as command arguments.
+    If the entry point is:
+        - A Python package: executes the packages as >>> env_vars python -m module_name + args
+        - A Python script: executes the script as >>> env_vars python module_name + args
+        - Any other: executes the command as >>> env_vars /bin/sh -c ./module_name + args
+
+    Example:
+         >>>import sagemaker_containers
+         >>>from sagemaker_containers.beta.framework import entry_point
+
+         >>>env = sagemaker_containers.training_env()
+         {'channel-input-dirs': {'training': '/opt/ml/input/training'}, 'model_dir': '/opt/ml/model', ...}
+
+
+         >>>hyperparameters = env.hyperparameters
+         {'batch-size': 128, 'model_dir': '/opt/ml/model'}
+
+         >>>args = mapping.to_cmd_args(hyperparameters)
+         ['--batch-size', '128', '--model_dir', '/opt/ml/model']
+
+         >>>env_vars = mapping.to_env_vars()
+         ['SAGEMAKER_CHANNELS':'training', 'SAGEMAKER_CHANNEL_TRAINING':'/opt/ml/input/training',
+         'MODEL_DIR':'/opt/ml/model', ...}
+
+         >>>entry_point.run('user_script', args, env_vars)
+         SAGEMAKER_CHANNELS=training SAGEMAKER_CHANNEL_TRAINING=/opt/ml/input/training \
+         SAGEMAKER_MODEL_DIR=/opt/ml/model python -m user_script --batch-size 128 --model_dir /opt/ml/model
+
+     Args:
+        user_entry_point (str): name of the user entrypoint
+        args (list):  A list of program arguments.
+        env_vars (dict): A map containing the environment variables to be written.
+        uri (str): the location of the module.
+        wait (bool): If True, holds the process executing the user entry-point.
+                     If False, returns the process that is executing it.
+     """
+    env_vars = env_vars or {}
+    env_vars = env_vars.copy()
+
+    _files.download_and_extract(uri, user_entry_point, _env.code_dir)
+
+    install(user_entry_point, _env.code_dir)
+
+    _env.write_env_vars(env_vars)
+
+    return call(user_entry_point, args, env_vars, wait)
+
+
+def install(name, dst):
+    """Install the user provided entry point to be executed as follow:
+        - add the path to sys path
+        - if the entrypoint is a command, gives exec permissions to the script
+
+    Args:
+        name (str): name of the script or module.
+        dst (str): path to directory with the script or module.
+    """
+    if dst not in sys.path:
+        sys.path.insert(0, dst)
+
+    entrypoint_type = entry_point_type(dst, name)
+    if entrypoint_type is EntryPointType.PYTHON_PACKAGE:
+        _modules.install(dst)
+    if entrypoint_type is EntryPointType.COMMAND:
+        os.chmod(os.path.join(dst, name), 511)
+
+
+def call(user_entry_point, args=None, env_vars=None, wait=True):  # type: (str, list, dict, bool) -> Popen
+    """Runs the entry-point, passing env_vars as environment variables and args as command arguments.
+    If the entry point is:
+        - A Python package: executes the packages as >>> env_vars python -m module_name + args
+        - A Python script: executes the script as >>> env_vars python module_name + args
+        - Any other: executes the command as >>> env_vars /bin/sh -c ./module_name + args
+
+    Example:
+
+        >>>import sagemaker_containers
+        >>>from sagemaker_containers.beta.framework import mapping, modules
+
+        >>>env = sagemaker_containers.training_env()
+        {'channel-input-dirs': {'training': '/opt/ml/input/training'}, 'model_dir': '/opt/ml/model', ...}
+
+
+        >>>hyperparameters = env.hyperparameters
+        {'batch-size': 128, 'model_dir': '/opt/ml/model'}
+
+        >>>args = mapping.to_cmd_args(hyperparameters)
+        ['--batch-size', '128', '--model_dir', '/opt/ml/model']
+
+        >>>env_vars = mapping.to_env_vars()
+        ['SAGEMAKER_CHANNELS':'training', 'SAGEMAKER_CHANNEL_TRAINING':'/opt/ml/input/training',
+        'MODEL_DIR':'/opt/ml/model', ...}
+
+        >>>modules.run('user_script', args, env_vars)
+        SAGEMAKER_CHANNELS=training SAGEMAKER_CHANNEL_TRAINING=/opt/ml/input/training \
+        SAGEMAKER_MODEL_DIR=/opt/ml/model python -m user_script --batch-size 128 --model_dir /opt/ml/model
+
+    Args:
+        user_entry_point (str): module name in the same format required by python -m <module-name> cli command.
+        args (list):  A list of program arguments.
+        env_vars (dict): A map containing the environment variables to be written.
+        wait (bool): If True, holds the process executing the user entry-point.
+                     If False, returns the process that is executing it.
+    """
+    args = args or []
+    env_vars = env_vars or {}
+
+    entrypoint_type = entry_point_type(_env.code_dir, user_entry_point)
+
+    if entrypoint_type is EntryPointType.PYTHON_PACKAGE:
+        cmd = [_process.python_executable(), '-m', user_entry_point.replace('.py', '')] + args
+    elif entrypoint_type is EntryPointType.PYTHON_PROGRAM:
+        cmd = [_process.python_executable(), user_entry_point] + args
+    else:
+        cmd = ['/bin/sh', '-c', './%s %s' % (user_entry_point, ' '.join(args))]
+
+    _logging.log_script_invocation(cmd, env_vars)
+
+    if wait:
+        return _process.check_error(cmd, _errors.ExecuteUserScriptError)
+
+    else:
+        return _process.create(cmd, _errors.ExecuteUserScriptError)
+
+
+class EntryPointType(enum.Enum):
+    PYTHON_PACKAGE = 'PYTHON_PACKAGE'
+    PYTHON_PROGRAM = 'PYTHON_PROGRAM'
+    COMMAND = 'COMMAND'
+
+
+def entry_point_type(path, name):  # type: (str, str) -> EntryPointType
+    """
+    Args:
+        path (string): Directory where the entry point is located
+        name (string): Name of the entry point file
+
+    Returns:
+        (EntryPointType): The type of the entry point
+    """
+    if 'setup.py' in os.listdir(path):
+        return EntryPointType.PYTHON_PACKAGE
+    elif name.endswith('.py'):
+        return EntryPointType.PYTHON_PROGRAM
+    else:
+        return EntryPointType.COMMAND

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,6 +44,7 @@ def create_base_path():
 
     os.makedirs(_env.model_dir)
     os.makedirs(_env.input_config_dir)
+    os.makedirs(_env.code_dir)
     os.makedirs(_env.output_data_dir)
 
     _write_json({}, _env.hyperparameters_file_dir)

--- a/test/functional/simple_framework.py
+++ b/test/functional/simple_framework.py
@@ -21,7 +21,7 @@ from sagemaker_containers.beta.framework import functions, modules
 def train():
     training_env = sagemaker_containers.training_env()
 
-    script = modules.import_module(training_env.module_dir, training_env.module_name, False)
+    script = modules.import_module(training_env.module_dir, training_env.module_name)
 
     model = script.train(**functions.matching_args(script.train, training_env))
 

--- a/test/functional/test_download_and_import.py
+++ b/test/functional/test_download_and_import.py
@@ -24,9 +24,9 @@ import test
 data = ['from distutils.core import setup\n',
         'setup(name="my_test_script", py_modules=["my_test_script"])']
 
-SETUP = test.File('setup.py', data)
+SETUP_FILE = test.File('setup.py', data)
 
-USER_SCRIPT = test.File('my_test_script.py', 'def validate(): return True')
+USER_SCRIPT_FILE = test.File('my_test_script.py', 'def validate(): return True')
 
 
 @pytest.fixture(name='user_module_name')
@@ -40,15 +40,15 @@ def erase_user_module():
 
 
 def test_import_module(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT).add_file(SETUP).upload()
+    user_module = test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE).upload()
 
-    module = modules.import_module(user_module.url, user_module_name, cache=False)
+    module = modules.import_module(user_module.url, user_module_name)
 
     assert module.validate()
 
 
 def test_import_module_with_s3_script(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT).upload()
+    user_module = test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE).upload()
 
     module = modules.import_module(user_module.url, user_module_name, cache=False)
 
@@ -58,7 +58,7 @@ def test_import_module_with_s3_script(user_module_name):
 def test_import_module_with_local_script(user_module_name, tmpdir):
     tmp_code_dir = str(tmpdir)
 
-    test.UserModule(USER_SCRIPT).create_tmp_dir_with_files(tmp_code_dir)
+    test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE).create_tmp_dir_with_files(tmp_code_dir)
 
     module = modules.import_module(tmp_code_dir, user_module_name, cache=False)
 
@@ -79,7 +79,8 @@ REQUIREMENTS_FILE = test.File('requirements.txt', 'pyfiglet')
 
 
 def test_import_module_with_s3_script_with_requirements(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT_WITH_REQUIREMENTS).add_file(REQUIREMENTS_FILE).upload()
+    user_module = test.UserModule(USER_SCRIPT_WITH_REQUIREMENTS).add_file(SETUP_FILE)
+    user_module = user_module.add_file(REQUIREMENTS_FILE).upload()
 
     module = modules.import_module(user_module.url, user_module_name, cache=False)
 
@@ -93,34 +94,12 @@ def test_import_module_with_s3_script_with_requirements(user_module_name):
 """.replace('.', ' ').strip()  # noqa W605
 
 
-data = textwrap.dedent("""
-            import file_2
-
-
-            def validate():
-                return file_2.IMPORTED
-""")
-
-USER_SCRIPT_WITH_ADDITIONAL_FILE = test.File('my_test_script.py', data)
-
-ADDITIONAL_FILE = test.File('file_2.py', 'IMPORTED = True')
-
-
-def test_import_module_with_s3_script_with_additional_files(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT_WITH_ADDITIONAL_FILE).add_file(ADDITIONAL_FILE).upload()
-
-    module = modules.import_module(user_module.url, user_module_name, cache=False)
-
-    assert module.validate()
-
-
 data = ['raise ValueError("this script does not work")']
-
 USER_SCRIPT_WITH_ERROR = test.File('my_test_script.py', data)
 
 
 def test_import_module_with_s3_script_with_error(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT_WITH_ERROR).upload()
+    user_module = test.UserModule(USER_SCRIPT_WITH_ERROR).add_file(SETUP_FILE).upload()
 
     with pytest.raises(errors.ImportModuleError):
         modules.import_module(user_module.url, user_module_name, cache=False)

--- a/test/functional/test_training_framework.py
+++ b/test/functional/test_training_framework.py
@@ -22,7 +22,7 @@ import numpy as np
 import pytest
 
 import sagemaker_containers
-from sagemaker_containers.beta.framework import env, errors, functions, modules, trainer
+from sagemaker_containers.beta.framework import entrypoint, env, errors, functions, modules, trainer
 import test
 from test import fake_ml_framework
 
@@ -101,7 +101,7 @@ parser.add_argument('--model_dir', type=str)
 
 args = parser.parse_args()
 
-data = np.load(args.training_data_file)
+data = np.load(os.path.join(os.environ['SM_CHANNEL_TRAINING'], args.training_data_file))
 x_train = data['features']
 y_train = data['labels']
 
@@ -109,9 +109,11 @@ model = fake_ml.Model(loss='elastic', optimizer='SGD')
 
 model.fit(x=x_train, y=y_train, epochs=args.epochs, batch_size=args.batch_size)
 
-model_file = os.path.join(args.model_dir, 'saved_model')
+model_file = os.path.join(os.environ['SM_MODEL_DIR'], 'saved_model')
 model.save(model_file)
 """
+
+BASH_SCRIPT = '#!/usr/bin/env python\n%s' % USER_MODE_SCRIPT
 
 PARAMETER_SERVER_SCRIPT = """
 from time import sleep
@@ -120,6 +122,14 @@ while True:
     print('Running parameter server')
     sleep(1)
 """
+
+setup_file = test.File('setup.py', """
+from setuptools import setup
+setup(packages=[''],
+      name="user_script",
+      version='1.0.0',
+      include_package_data=True)
+""")
 
 
 def framework_training_fn():
@@ -148,7 +158,8 @@ def test_training_framework(user_script):
     labels = [0, 1, 0, 1]
     np.savez(os.path.join(channel.path, 'training_data'), features=features, labels=labels)
 
-    module = test.UserModule(test.File(name='user_script.py', data=user_script))
+    file = test.File(name='user_script.py', data=user_script)
+    module = test.UserModule(file).add_file(setup_file)
 
     hyperparameters = dict(training_data_file='training_data.npz', sagemaker_program='user_script.py', epochs=10,
                            batch_size=64, optimizer='Adam')
@@ -165,10 +176,11 @@ def test_training_framework(user_script):
     assert model.optimizer == 'Adam'
 
 
-@pytest.mark.parametrize('user_script', [USER_SCRIPT, USER_SCRIPT_WITH_SAVE])
-def test_trainer_report_success(user_script):
-    with pytest.raises(ImportError):
-        importlib.import_module(modules.DEFAULT_MODULE_NAME)
+@pytest.mark.parametrize('user_script, sagemaker_program', [
+    [USER_MODE_SCRIPT, 'user_script.py'],
+    [BASH_SCRIPT, 'bash_script']
+])
+def test_trainer_report_success(user_script, sagemaker_program):
 
     channel = test.Channel.create(name='training')
 
@@ -176,14 +188,12 @@ def test_trainer_report_success(user_script):
     labels = [0, 1, 0, 1]
     np.savez(os.path.join(channel.path, 'training_data'), features=features, labels=labels)
 
-    module = test.UserModule(test.File(name='user_script.py', data=user_script))
+    module = test.UserModule(test.File(name=sagemaker_program, data=user_script))
 
-    hyperparameters = dict(training_data_file='training_data.npz', sagemaker_program='user_script.py', epochs=10,
-                           batch_size=64, optimizer='SGD')
+    hyperparameters = dict(training_data_file='training_data.npz', sagemaker_program=sagemaker_program, epochs=10,
+                           batch_size=64)
 
     test.prepare(user_module=module, hyperparameters=hyperparameters, channels=[channel])
-
-    os.environ['SAGEMAKER_TRAINING_MODULE'] = 'test.functional.simple_framework:train'
 
     assert execute_an_wrap_exit(trainer.train) == trainer.SUCCESS_CODE
 
@@ -204,7 +214,7 @@ def test_trainer_report_failure():
     labels = [0, 1, 0, 1]
     np.savez(os.path.join(channel.path, 'training_data'), features=features, labels=labels)
 
-    module = test.UserModule(test.File(name='user_script.py', data=USER_SCRIPT_WITH_EXCEPTION))
+    module = test.UserModule(test.File(name='user_script.py', data=USER_SCRIPT_WITH_EXCEPTION)).add_file(setup_file)
 
     hyperparameters = dict(training_data_file='training_data.npz', sagemaker_program='user_script.py', epochs=10,
                            batch_size=64)
@@ -227,8 +237,8 @@ def test_trainer_report_failure():
 def framework_training_with_script_mode_fn():
     training_env = sagemaker_containers.training_env()
 
-    modules.run_module(training_env.module_dir, training_env.to_cmd_args(), training_env.to_env_vars(),
-                       training_env.module_name, cache=False)
+    entrypoint.run(training_env.module_dir, training_env.user_entry_point, training_env.to_cmd_args(),
+                   training_env.to_env_vars())
 
 
 def test_parameter_server():
@@ -237,8 +247,8 @@ def test_parameter_server():
 
     test.prepare(user_module=module, hyperparameters=hyperparameters, channels=[test.Channel.create(name='training')])
     training_env = sagemaker_containers.training_env()
-    process = modules.run_module(training_env.module_dir, training_env.to_cmd_args(), training_env.to_env_vars(),
-                                 training_env.module_name, cache=False, wait=False)
+    process = entrypoint.run(training_env.module_dir, training_env.user_entry_point,
+                             training_env.to_cmd_args(), training_env.to_env_vars(), wait=False)
     # confirm the ps process is still hanging
     assert process.poll() is None
     process.kill()
@@ -329,10 +339,10 @@ def test_script_mode_client_import_error():
 
     requirements_file = test.File('requirements.txt', '42/0')
 
-    user_script = test.File(name='user_script.py', data='42/0')
-    module = test.UserModule(user_script).add_file(requirements_file).upload()
+    user_script = test.File(name='user_script', data='42/0')
+    module = test.UserModule(user_script).add_file(setup_file).add_file(requirements_file).upload()
 
-    hyperparameters = dict(sagemaker_program='user_script.py')
+    hyperparameters = dict(sagemaker_program='user_script')
 
     test.prepare(user_module=module, hyperparameters=hyperparameters, channels=[channel])
 

--- a/test/unit/test_entry_point.py
+++ b/test/unit/test_entry_point.py
@@ -1,0 +1,142 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import os
+import sys
+
+from mock import patch
+import pytest
+from six import PY2
+
+from sagemaker_containers import _env, _errors, entrypoint
+
+builtins_open = '__builtin__.open' if PY2 else 'builtins.open'
+
+
+@pytest.fixture
+def entrypoint_type_module():
+    with patch('os.listdir', lambda x: ('setup.py',)):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def entrypoint_type_script():
+    with patch('os.listdir', lambda x: ()):
+        yield
+
+
+@pytest.fixture()
+def has_requirements():
+    with patch('os.path.exists', lambda x: x.endswith('requirements.txt')):
+        yield
+
+
+@patch('sagemaker_containers._process.check_error', autospec=True)
+def test_install_module(check_error, entrypoint_type_module):
+    path = 'c://sagemaker-pytorch-container'
+    entrypoint.install('python_module.py', path)
+
+    cmd = [sys.executable, '-m', 'pip', 'install', '-U', '.']
+    check_error.assert_called_with(cmd, _errors.InstallModuleError, cwd=path)
+
+    with patch('os.path.exists', return_value=True):
+        entrypoint.install('python_module.py', path)
+
+        check_error.assert_called_with(cmd + ['-r', 'requirements.txt'], _errors.InstallModuleError, cwd=path)
+
+
+@patch('sagemaker_containers._process.check_error', autospec=True)
+def test_install_script(check_error, entrypoint_type_module, has_requirements):
+    path = 'c://sagemaker-pytorch-container'
+    entrypoint.install('train.py', path)
+
+    with patch('os.path.exists', return_value=True):
+        entrypoint.install(path, 'python_module.py')
+
+
+@patch('sagemaker_containers._process.check_error', autospec=True)
+def test_install_fails(check_error, entrypoint_type_module):
+    check_error.side_effect = _errors.ClientError()
+    with pytest.raises(_errors.ClientError):
+        entrypoint.install('git://aws/container-support', 'script')
+
+
+@patch('sys.executable', None)
+def test_install_no_python_executable(has_requirements, entrypoint_type_module):
+    with pytest.raises(RuntimeError) as e:
+        entrypoint.install('train.py', 'git://aws/container-support')
+    assert str(e.value) == 'Failed to retrieve the real path for the Python executable binary'
+
+
+@patch('subprocess.Popen')
+@patch('sagemaker_containers._logging.log_script_invocation')
+def test_run_bash(log, popen, entrypoint_type_script):
+    with pytest.raises(_errors.ExecuteUserScriptError):
+        entrypoint.call('launcher.sh', ['--lr', '13'])
+
+    cmd = ['/bin/sh', '-c', './launcher.sh --lr 13']
+    popen.assert_called_with(cmd, cwd=_env.code_dir, env=os.environ)
+    log.assert_called_with(cmd, {})
+
+
+@patch('subprocess.Popen')
+@patch('sagemaker_containers._logging.log_script_invocation')
+def test_run_python(log, popen, entrypoint_type_script):
+    with pytest.raises(_errors.ExecuteUserScriptError):
+        entrypoint.call('launcher.py', ['--lr', '13'])
+
+    cmd = [sys.executable, 'launcher.py', '--lr', '13']
+    popen.assert_called_with(cmd, cwd=_env.code_dir, env=os.environ)
+    log.assert_called_with(cmd, {})
+
+
+@patch('subprocess.Popen')
+@patch('sagemaker_containers._logging.log_script_invocation')
+def test_run_module(log, popen, entrypoint_type_module):
+    with pytest.raises(_errors.ExecuteUserScriptError):
+        entrypoint.call('module.py', ['--lr', '13'])
+
+    cmd = [sys.executable, '-m', 'module', '--lr', '13']
+    popen.assert_called_with(cmd, cwd=_env.code_dir, env=os.environ)
+    log.assert_called_with(cmd, {})
+
+
+@patch('sagemaker_containers.training_env', lambda: {})
+def test_run_error():
+    with pytest.raises(_errors.ExecuteUserScriptError) as e:
+        entrypoint.call('wrong module')
+
+    message = str(e.value)
+    assert 'ExecuteUserScriptError:' in message
+
+
+@patch('sagemaker_containers._files.download_and_extract')
+@patch('sagemaker_containers.entrypoint.call')
+@patch('os.chmod')
+def test_run_module_wait(chmod, call, download_and_extract):
+    entrypoint.run(uri='s3://url', user_entry_point='launcher.sh', args=['42'])
+
+    download_and_extract.assert_called_with('s3://url', 'launcher.sh', _env.code_dir)
+    call.assert_called_with('launcher.sh', ['42'], {}, True)
+    chmod.assert_called_with(os.path.join(_env.code_dir, 'launcher.sh'), 511)
+
+
+@patch('sagemaker_containers._files.download_and_extract')
+@patch('sagemaker_containers.entrypoint.call')
+def test_run_module_no_wait(call, download_and_extract, entrypoint_type_module):
+    with pytest.raises(_errors.InstallModuleError):
+        entrypoint.run(uri='s3://url', user_entry_point='default_user_module_name', args=['42'], wait=False)
+
+        download_and_extract.assert_called_with('s3://url', 'default_user_module_name', _env.code_dir)
+        call.assert_called_with('default_user_module_name', ['42'], {}, False)

--- a/test/unit/test_environment.py
+++ b/test/unit/test_environment.py
@@ -193,6 +193,7 @@ def test_training_env(training_env):
     assert training_env.channel_input_dirs['validation'].endswith('/opt/ml/input/data/validation')
     assert training_env.current_host == RESOURCE_CONFIG['current_host']
     assert training_env.module_name == 'main'
+    assert training_env.user_entry_point == 'main.py'
     assert training_env.module_dir == 'imagenet'
     assert training_env.log_level == logging.WARNING
     assert training_env.network_interface_name == 'ethwe'
@@ -207,27 +208,30 @@ def test_serving_env(serving_env):
     assert serving_env.model_server_timeout == 20
     assert serving_env.model_server_workers == 8
     assert serving_env.module_name == 'main'
+    assert serving_env.user_entry_point == 'main.py'
     assert serving_env.framework_module is None
 
 
 def test_env_mapping_properties(training_env):
-    assert sorted(training_env.properties()) == sorted(
-        ['additional_framework_parameters', 'channel_input_dirs', 'current_host', 'framework_module', 'hosts',
-         'hyperparameters', 'input_config_dir', 'input_data_config', 'input_dir', 'log_level', 'model_dir',
-         'module_dir', 'module_name', 'network_interface_name', 'num_cpus', 'num_gpus', 'output_data_dir',
-         'output_dir', 'resource_config', 'job_name'])
+    assert set(training_env.properties()) == {
+        'additional_framework_parameters', 'channel_input_dirs', 'current_host', 'framework_module', 'hosts',
+        'hyperparameters', 'input_config_dir', 'input_data_config', 'input_dir', 'log_level', 'model_dir',
+        'module_dir', 'module_name', 'network_interface_name', 'num_cpus', 'num_gpus', 'output_data_dir',
+        'output_dir', 'resource_config', 'user_entry_point', 'job_name'}
 
 
 def test_serving_env_properties(serving_env):
-    assert serving_env.properties() == ['current_host', 'default_accept', 'framework_module', 'http_port', 'log_level',
-                                        'model_dir', 'model_server_timeout', 'model_server_workers', 'module_dir',
-                                        'module_name', 'num_cpus', 'num_gpus', 'safe_port_range', 'use_nginx']
+    assert set(serving_env.properties()) == {
+        'current_host', 'default_accept', 'framework_module', 'http_port', 'log_level', 'model_dir',
+        'model_server_timeout', 'model_server_workers', 'module_dir', 'module_name', 'num_cpus',
+        'num_gpus', 'safe_port_range', 'user_entry_point', 'use_nginx'}
 
 
 def test_request_properties(serving_env):
-    assert serving_env.properties() == ['current_host', 'default_accept', 'framework_module', 'http_port', 'log_level',
-                                        'model_dir', 'model_server_timeout', 'model_server_workers', 'module_dir',
-                                        'module_name', 'num_cpus', 'num_gpus', 'safe_port_range', 'use_nginx']
+    assert set(serving_env.properties()) == {
+        'current_host', 'default_accept', 'framework_module', 'http_port', 'log_level', 'model_dir',
+        'model_server_timeout', 'model_server_workers', 'module_dir', 'module_name', 'num_cpus',
+        'num_gpus', 'user_entry_point', 'safe_port_range', 'use_nginx'}
 
 
 @patch('sagemaker_containers._env.num_cpus', lambda: 8)

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -13,18 +13,14 @@
 from __future__ import absolute_import
 
 import contextlib
-import importlib
 import os
 import sys
-import tarfile
-import textwrap
 
-from mock import call, mock_open, patch
+from mock import call, patch
 import pytest
 from six import PY2
 
-from sagemaker_containers import _errors, _modules, _params
-import test
+from sagemaker_containers import _env, _errors, _files, _modules, _params
 
 builtins_open = '__builtin__.open' if PY2 else 'builtins.open'
 
@@ -37,61 +33,18 @@ def test_s3_download(resource, url, bucket_name, key, dst):
     region = 'us-west-2'
     os.environ[_params.REGION_NAME_ENV] = region
 
-    _modules.s3_download(url, dst)
+    _files.s3_download(url, dst)
 
     chain = call('s3', region_name=region).Bucket(bucket_name).download_file(key, dst)
     assert resource.mock_calls == chain.call_list()
 
 
-@patch(builtins_open, mock_open())
-@patch('os.path.exists', lambda x: False)
-def test_prepare():
-    _modules.prepare('c:/path/to/', 'my-module')
-
-    open.assert_any_call('c:/path/to/setup.py', 'w')
-    open.assert_any_call('c:/path/to/setup.cfg', 'w')
-    open.assert_any_call('c:/path/to/MANIFEST.in', 'w')
-
-    data = textwrap.dedent("""
-    from setuptools import setup
-
-    setup(packages=[''],
-          name="my-module",
-          version='1.0.0',
-          include_package_data=True)
-    """)
-
-    open().write.assert_any_call(data)
-
-    data = textwrap.dedent("""
-    [wheel]
-    universal = 1
-    """)
-    open().write.assert_any_call(data)
-
-    data = textwrap.dedent("""
-    recursive-include . *
-
-    recursive-exclude . __pycache__*
-    recursive-exclude . *.pyc
-    recursive-exclude . *.pyo
-    """)
-    open().write.assert_any_call(data)
-
-
-@patch(builtins_open, mock_open())
-@patch('os.path.exists', lambda x: True)
-def test_prepare_already_prepared():
-    _modules.prepare('c:/path/to/', 'my-module')
-    open.assert_not_called()
-
-
 def test_s3_download_wrong_scheme():
     with pytest.raises(ValueError, message="Expecting 's3' scheme, got: c in c://my-bucket/my-file"):
-        _modules.s3_download('c://my-bucket/my-file', '/tmp/file')
+        _files.s3_download('c://my-bucket/my-file', '/tmp/file')
 
 
-@patch('sagemaker_containers._modules._check_error', autospec=True)
+@patch('sagemaker_containers._process.check_error', autospec=True)
 def test_install(check_error):
     path = 'c://sagemaker-pytorch-container'
     _modules.install(path)
@@ -105,7 +58,7 @@ def test_install(check_error):
         check_error.assert_called_with(cmd + ['-r', 'requirements.txt'], _errors.InstallModuleError, cwd=path)
 
 
-@patch('sagemaker_containers._modules._check_error', autospec=True)
+@patch('sagemaker_containers._process.check_error', autospec=True)
 def test_install_fails(check_error):
     check_error.side_effect = _errors.ClientError()
     with pytest.raises(_errors.ClientError):
@@ -142,111 +95,53 @@ def test_run_error():
     assert 'ExecuteUserScriptError:' in message
 
 
-def test_python_executable_exception():
-    with patch('sys.executable', None):
-        with pytest.raises(RuntimeError):
-            _modules.python_executable()
-
-
-@patch('sagemaker_containers.training_env', lambda: {})
-def test_run():
+@patch('sagemaker_containers._process.python_executable')
+@patch('sagemaker_containers._process.check_error')
+@patch('sagemaker_containers._logging.log_script_invocation')
+def test_run(log_script_invocation,  check_error, executable):
     _modules.run('pytest', ['--version'])
 
-
-def test_run_module_wait():
-    with patch('sagemaker_containers._modules.download_and_install') as download_and_install:
-        with patch('sagemaker_containers._modules.run') as run:
-            _modules.run_module(uri='s3://url', args=['42'], cache=True)
-
-            download_and_install.assert_called_with('s3://url', 'default_user_module_name', True)
-            run.assert_called_with('default_user_module_name', ['42'], {}, True)
+    expected_cmd = [executable(), '-m', 'pytest', '--version']
+    log_script_invocation.assert_called_with(expected_cmd, {})
+    check_error.assert_called_with(expected_cmd, _errors.ExecuteUserScriptError)
 
 
-def test_run_module_no_wait():
-    with patch('sagemaker_containers._modules.download_and_install') as download_and_install:
-        with patch('sagemaker_containers._modules.run') as run:
-            _modules.run_module(uri='s3://url', args=['42'], cache=True, wait=False)
+@patch('sagemaker_containers._process.python_executable')
+@patch('sagemaker_containers._process.create')
+@patch('sagemaker_containers._logging.log_script_invocation')
+def test_run_no_wait(log_script_invocation,  create, executable):
+    _modules.run('pytest', ['--version'], {'PYPATH': '/opt/ml/code'}, wait=False)
 
-            download_and_install.assert_called_with('s3://url', 'default_user_module_name', True)
-            run.assert_called_with('default_user_module_name', ['42'], {}, False)
-
-
-def test_download_and_install_local_directory():
-    uri = '/opt/ml/code'
-
-    with patch('sagemaker_containers._modules.s3_download') as s3_download, \
-            patch('sagemaker_containers._modules.prepare') as prepare, \
-            patch('sagemaker_containers._modules.install') as install:
-        _modules.download_and_install(uri)
-
-        s3_download.assert_not_called()
-        prepare.assert_called_with(uri, 'default_user_module_name')
-        install.assert_called_with(uri)
+    expected_cmd = [executable(), '-m', 'pytest', '--version']
+    log_script_invocation.assert_called_with(expected_cmd, {'PYPATH': '/opt/ml/code'})
+    create.assert_called_with(expected_cmd, _errors.ExecuteUserScriptError)
 
 
-class TestDownloadAndImport(test.TestBase):
-    patches = [patch('sagemaker_containers._files.tmpdir', new=patch_tmpdir),
-               patch('sagemaker_containers._modules.prepare', autospec=True),
-               patch('sagemaker_containers._modules.install', autospec=True),
-               patch('sagemaker_containers._modules.s3_download', autospec=True),
-               patch('sagemaker_containers._modules.exists', autospec=True), patch('tarfile.open', autospec=True),
-               patch('importlib.import_module', autospec=True), patch('six.moves.reload_module', autospec=True),
-               patch('os.makedirs', autospec=True)]
+@pytest.mark.parametrize('wait, cache', [[True, False], [True, False]])
+@patch('sagemaker_containers._modules.run')
+@patch('sagemaker_containers._modules.install')
+@patch('sagemaker_containers._env.write_env_vars')
+@patch('sagemaker_containers._files.download_and_extract')
+def test_run_module_wait(download_and_extract, write_env_vars, install, run, wait, cache):
+    with pytest.warns(DeprecationWarning):
+        _modules.run_module(uri='s3://url', args=['42'], wait=wait, cache=cache)
+        module_name = 'default_user_module_name'
 
-    def test_without_cache(self):
-        with tarfile.open() as tar_file:
-            module = _modules.import_module('s3://bucket/my-module', cache=False)
+        download_and_extract.assert_called_with('s3://url', module_name, _env.code_dir)
+        write_env_vars.assert_called_with({})
+        install.assert_called_with(_env.code_dir)
 
-            assert module == importlib.import_module(_modules.DEFAULT_MODULE_NAME)
+        run.assert_called_with('default_user_module_name', ['42'], {}, True)
 
-            _modules.s3_download.assert_called_with('s3://bucket/my-module', '/tmp/tar_file')
-            os.makedirs.assert_called_with('/tmp/module_dir')
 
-            tar_file.extractall.assert_called_with(path='/tmp/module_dir')
-            _modules.prepare.assert_called_with('/tmp/module_dir', _modules.DEFAULT_MODULE_NAME)
-            _modules.install.assert_called_with('/tmp/module_dir')
+@patch('sagemaker_containers._files.download_and_extract')
+@patch('sagemaker_containers._modules.install')
+@patch('importlib.import_module')
+@patch('six.moves.reload_module')
+def test_import_module(reload, import_module, install, download_and_extract):
 
-    def test_with_cache_and_module_already_installed(self):
-        with tarfile.open() as tar_file:
-            _modules.exists.return_value = True
+    _modules.import_module('s3://bucket/my-module')
 
-            module = _modules.import_module('s3://bucket/my-module', cache=True)
-
-            assert module == importlib.import_module(_modules.DEFAULT_MODULE_NAME)
-
-            _modules.s3_download.return_value.assert_not_called()
-            os.makedirs.return_value.assert_not_called()
-
-            tar_file.extractall.return_value.assert_not_called()
-            _modules.prepare.return_value.assert_not_called()
-            _modules.install.return_value.assert_not_called()
-
-    def test_default_name(self):
-        with tarfile.open() as tar_file:
-            _modules.exists.return_value = False
-
-            module = _modules.import_module('s3://bucket/my-module', cache=True)
-
-            assert module == importlib.import_module(_modules.DEFAULT_MODULE_NAME)
-
-            _modules.s3_download.assert_called_with('s3://bucket/my-module', '/tmp/tar_file')
-            os.makedirs.assert_called_with('/tmp/module_dir')
-
-            tar_file.extractall.assert_called_with(path='/tmp/module_dir')
-            _modules.prepare.assert_called_with('/tmp/module_dir', _modules.DEFAULT_MODULE_NAME)
-            _modules.install.assert_called_with('/tmp/module_dir')
-
-    def test_any_name(self):
-        with tarfile.open() as tar_file:
-            _modules.exists.return_value = False
-
-            module = _modules.import_module('s3://bucket/my-module', 'another_module_name', cache=True)
-
-            assert module == importlib.import_module('another_module_name')
-
-            _modules.s3_download.assert_called_with('s3://bucket/my-module', '/tmp/tar_file')
-            os.makedirs.assert_called_with('/tmp/module_dir')
-
-            tar_file.extractall.assert_called_with(path='/tmp/module_dir')
-            _modules.prepare.assert_called_with('/tmp/module_dir', 'another_module_name')
-            _modules.install.assert_called_with('/tmp/module_dir')
+    download_and_extract.assert_called_with('s3://bucket/my-module', 'default_user_module_name', _env.code_dir)
+    install.assert_called_with(_env.code_dir)
+    reload.assert_called_with(import_module(_modules.DEFAULT_MODULE_NAME))

--- a/test/unit/test_process.py
+++ b/test/unit/test_process.py
@@ -1,0 +1,38 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from mock import MagicMock, patch
+import pytest
+
+from sagemaker_containers import _errors, _process
+
+
+def test_python_executable_exception():
+    with patch('sys.executable', None):
+        with pytest.raises(RuntimeError):
+            _process.python_executable()
+
+
+@patch('subprocess.Popen', MagicMock(side_effect=ValueError('FAIL')))
+def test_create_error():
+    with pytest.raises(_errors.ExecuteUserScriptError):
+        _process.create(['run'], _errors.ExecuteUserScriptError)
+
+
+@patch('subprocess.Popen')
+def test_check_error(popen):
+    process = MagicMock(wait=MagicMock(return_value=0))
+    popen.return_value = process
+
+    assert process == _process.check_error(['run'], _errors.ExecuteUserScriptError)

--- a/test/unit/test_trainer.py
+++ b/test/unit/test_trainer.py
@@ -23,6 +23,10 @@ class TrainingEnv(Mock):
     log_level = 20
 
 
+class SriptTrainingEnv(TrainingEnv):
+    framework_module = None
+
+
 @patch('importlib.import_module')
 @patch('sagemaker_containers.training_env', TrainingEnv)
 def test_train(import_module):
@@ -79,3 +83,16 @@ def test_train_with_client_error(_exit, import_module):
     _trainer.train()
 
     _exit.assert_called_with(_trainer.DEFAULT_FAILURE_CODE)
+
+
+@patch('sagemaker_containers.entrypoint.run')
+@patch('sagemaker_containers.training_env', new_callable=SriptTrainingEnv)
+@patch('sagemaker_containers._trainer._exit_processes')
+def test_train_script(_exit, training_env, run):
+    _trainer.train()
+
+    env = training_env()
+    run.assert_called_with(env.module_dir, env.user_entry_point, env.to_cmd_args(),
+                           env.to_env_vars())
+
+    _exit.assert_called_with(_trainer.SUCCESS_CODE)


### PR DESCRIPTION
# Support for bash script

## before changes

```python
estimator = MXNET(entrypoint='train.py')
```
Script mode will:

1. Add a setup.py to the script if it doesn't exist (https://github.com/aws/sagemaker-containers/blob/d20115a8a2c7024b496a94700237c641b0bf453b/src/sagemaker_containers/_modules.py#L54)  
2. Pip installs the customer script as a python package, using the requirements.txt file if provided (https://github.com/aws/sagemaker-containers/blob/d20115a8a2c7024b496a94700237c641b0bf453b/src/sagemaker_containers/_modules.py#L116)
3. Write the Training Environment as environment variables (https://github.com/aws/sagemaker-containers/blob/master/src/sagemaker_containers/_modules.py#L322): the list of env vars is here (https://github.com/aws/sagemaker-containers#list-of-provided-environment-variables-by-sagemaker-containers)
4. Runs the python *module* as follow:  cmd = [python_executable(), '-m', module_name] + args  where *args* are customer's hyperparameters

## proposed changes

### If the customer provides python script without setup.py:

```python
estimator = MXNET(entrypoint='train.py', source_dir='src')
```

Script mode will:

1. Copy src directory to /opt/ml/code
2. Write the Training Environment as environment variables (https://github.com/aws/sagemaker-containers/blob/master/src/sagemaker_containers/_modules.py#L322): the list of env vars is here (https://github.com/aws/sagemaker-containers#list-of-provided-environment-variables-by-sagemaker-containers)
3. add /opt/ml/code to PYTHONPATH
4. os.chdir('/opt/ml/code')
5. Runs the python *script* as follow:  cmd = [python_executable(), script_name] + args  where *args* are customers hyperparameters

### If customer provides a non python entrypoint

```python
estimator = MXNET(entrypoint='train.sh', source_dir='src')
```
or

```python
estimator = MXNET(entrypoint='train', source_dir='src')
```

Script mode will:

1. Copy src directory to /opt/ml/code
2. Write the Training Environment as environment variables (https://github.com/aws/sagemaker-containers/blob/master/src/sagemaker_containers/_modules.py#L322): the list of env vars is here (https://github.com/aws/sagemaker-containers#list-of-provided-environment-variables-by-sagemaker-containers)
3. add /opt/ml/code to PYTHONPATH
4. os.chdir('/opt/ml/code')
5. Runs the *script* as follow:  cmd = [script_name] + args  where *args* are customers hyperparameters

### If customer provides python script with setup.py

Script mode will keep the current functionality

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
