### PR TITLE
Bug fix: reintroduce _modules.prepare to import_module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+2.3.3
+=====
+
+* bug-fix: reintroduce _modules.prepare to import_module
+
 2.3.2
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='sagemaker_containers',
-    version='2.3.2',
+    version='2.3.3',
     description='Open source library for creating containers to run on Amazon SageMaker.',
 
     packages=packages,

--- a/src/sagemaker_containers/_modules.py
+++ b/src/sagemaker_containers/_modules.py
@@ -184,6 +184,7 @@ def import_module(uri, name=DEFAULT_MODULE_NAME, cache=None):  # type: (str, str
     _warning_cache_deprecation(cache)
     _files.download_and_extract(uri, name, _env.code_dir)
 
+    prepare(_env.code_dir, name)
     install(_env.code_dir)
     try:
         module = importlib.import_module(name)

--- a/test/functional/test_download_and_import.py
+++ b/test/functional/test_download_and_import.py
@@ -39,26 +39,35 @@ def erase_user_module():
         pass
 
 
-def test_import_module(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE).upload()
+@pytest.mark.parametrize('user_module',
+                         [test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE),
+                          test.UserModule(USER_SCRIPT_FILE)])
+def test_import_module(user_module, user_module_name):
+    user_module.upload()
 
     module = modules.import_module(user_module.url, user_module_name)
 
     assert module.validate()
 
 
-def test_import_module_with_s3_script(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE).upload()
+@pytest.mark.parametrize('user_module',
+                         [test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE),
+                          test.UserModule(USER_SCRIPT_FILE)])
+def test_import_module_with_s3_script(user_module, user_module_name):
+    user_module.upload()
 
     module = modules.import_module(user_module.url, user_module_name, cache=False)
 
     assert module.validate()
 
 
-def test_import_module_with_local_script(user_module_name, tmpdir):
+@pytest.mark.parametrize('user_module',
+                         [test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE),
+                          test.UserModule(USER_SCRIPT_FILE)])
+def test_import_module_with_local_script(user_module, user_module_name, tmpdir):
     tmp_code_dir = str(tmpdir)
 
-    test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE).create_tmp_dir_with_files(tmp_code_dir)
+    user_module.create_tmp_dir_with_files(tmp_code_dir)
 
     module = modules.import_module(tmp_code_dir, user_module_name, cache=False)
 
@@ -78,8 +87,10 @@ USER_SCRIPT_WITH_REQUIREMENTS = test.File('my_test_script.py', data)
 REQUIREMENTS_FILE = test.File('requirements.txt', 'pyfiglet')
 
 
-def test_import_module_with_s3_script_with_requirements(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT_WITH_REQUIREMENTS).add_file(SETUP_FILE)
+@pytest.mark.parametrize('user_module',
+                         [test.UserModule(USER_SCRIPT_WITH_REQUIREMENTS).add_file(SETUP_FILE),
+                          test.UserModule(USER_SCRIPT_WITH_REQUIREMENTS)])
+def test_import_module_with_s3_script_with_requirements(user_module, user_module_name):
     user_module = user_module.add_file(REQUIREMENTS_FILE).upload()
 
     module = modules.import_module(user_module.url, user_module_name, cache=False)


### PR DESCRIPTION
*Issue #, if available:*
import_module needs to use _modules.prepare as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
