### PR TITLE
Add capture_error flag to process.check_error and process.create

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+2.3.3
+=====
+
+* bug-fix: reintroduce _modules.prepare to import_module
+
 2.3.2
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,7 @@ CHANGELOG
 2.3.4
 =====
 
-* feature: add capture_error flag to process.check_error and process.create and to
-all functions that runs process: modules.run, modules,run_module, and entry_point.run
+* feature: add capture_error flag to process.check_error and process.create and to all functions that runs process: modules.run, modules,run_module, and entry_point.run
 
 2.3.3
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 CHANGELOG
 =========
 
+2.3.4
+=====
+
+* feature: add capture_error flag to process.check_error and process.create and to
+all functions that runs process: modules.run, modules,run_module, and entry_point.run
+
 2.3.3
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='sagemaker_containers',
-    version='2.3.3',
+    version='2.3.4',
     description='Open source library for creating containers to run on Amazon SageMaker.',
 
     packages=packages,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='sagemaker_containers',
-    version='2.3.2',
+    version='2.3.3',
     description='Open source library for creating containers to run on Amazon SageMaker.',
 
     packages=packages,

--- a/src/sagemaker_containers/_errors.py
+++ b/src/sagemaker_containers/_errors.py
@@ -39,7 +39,7 @@ class _CalledProcessError(ClientError):
 
         error_msg = decode_error() if self.output else ''
 
-        message = '%s:\nCommand "%s"\n%s' % (type(self).__name__, self.cmd, error_msg)
+        message = '%s:\nCommand "%s"%s' % (type(self).__name__, self.cmd, error_msg)
         return message.strip()
 
 

--- a/src/sagemaker_containers/_errors.py
+++ b/src/sagemaker_containers/_errors.py
@@ -34,10 +34,12 @@ class _CalledProcessError(ClientError):
         self.output = output
 
     def __str__(self):
-        def decode_error():
-            return '\n%s' % self.output.decode('latin1') if six.PY3 else self.output
-
-        error_msg = decode_error() if self.output else ''
+        if six.PY3 and self.output:
+            error_msg = '\n%s' % self.output.decode('latin1')
+        elif self.output:
+            error_msg = '\n%s' % self.output
+        else:
+            error_msg = ''
 
         message = '%s:\nCommand "%s"%s' % (type(self).__name__, self.cmd, error_msg)
         return message.strip()

--- a/src/sagemaker_containers/_errors.py
+++ b/src/sagemaker_containers/_errors.py
@@ -12,8 +12,9 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-import six
 import textwrap
+
+import six
 
 
 class ClientError(Exception):

--- a/src/sagemaker_containers/_errors.py
+++ b/src/sagemaker_containers/_errors.py
@@ -42,9 +42,6 @@ class _CalledProcessError(ClientError):
         message = '%s:\nCommand "%s"\n%s' % (type(self).__name__, self.cmd, error_msg)
         return message.strip()
 
-    def decode_error(self):
-        return self.output.decode('latin1') if six.PY3 else self.output
-
 
 class InstallModuleError(_CalledProcessError):
     pass

--- a/src/sagemaker_containers/_errors.py
+++ b/src/sagemaker_containers/_errors.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import six
 import textwrap
 
 
@@ -27,13 +28,22 @@ class _CalledProcessError(ClientError):
       cmd, return_code, output
     """
 
-    def __init__(self, cmd, return_code=None):
+    def __init__(self, cmd, return_code=None, output=None):
         self.return_code = return_code
         self.cmd = cmd
+        self.output = output
 
     def __str__(self):
-        message = '%s:\nCommand "%s"' % (type(self).__name__, self.cmd)
+        def decode_error():
+            return '\n%s' % self.output.decode('latin1') if six.PY3 else self.output
+
+        error_msg = decode_error() if self.output else ''
+
+        message = '%s:\nCommand "%s"\n%s' % (type(self).__name__, self.cmd, error_msg)
         return message.strip()
+
+    def decode_error(self):
+        return self.output.decode('latin1') if six.PY3 else self.output
 
 
 class InstallModuleError(_CalledProcessError):

--- a/src/sagemaker_containers/_modules.py
+++ b/src/sagemaker_containers/_modules.py
@@ -184,6 +184,7 @@ def import_module(uri, name=DEFAULT_MODULE_NAME, cache=None):  # type: (str, str
     _warning_cache_deprecation(cache)
     _files.download_and_extract(uri, name, _env.code_dir)
 
+    prepare(_env.code_dir, name)
     install(_env.code_dir)
     try:
         module = importlib.import_module(name)

--- a/src/sagemaker_containers/_modules.py
+++ b/src/sagemaker_containers/_modules.py
@@ -108,7 +108,8 @@ def install(path, capture_error=False):  # type: (str) -> None
     _process.check_error(shlex.split(cmd), _errors.InstallModuleError, cwd=path, capture_error=capture_error)
 
 
-def run(module_name, args=None, env_vars=None, wait=True, capture_error=False):  # type: (str, list, dict, bool) -> Popen
+def run(module_name, args=None, env_vars=None, wait=True, capture_error=False):
+    # type: (str, list, dict, bool, bool) -> Popen
     """Run Python module as a script.
 
     Search sys.path for the named module and execute its contents as the __main__ module.

--- a/src/sagemaker_containers/_modules.py
+++ b/src/sagemaker_containers/_modules.py
@@ -91,7 +91,7 @@ def prepare(path, name):  # type: (str, str) -> None
         _files.write_file(os.path.join(path, 'MANIFEST.in'), data)
 
 
-def install(path):  # type: (str) -> None
+def install(path, capture_error=False):  # type: (str) -> None
     """Install a Python module in the executing Python environment.
     Args:
         path (str):  Real path location of the Python module.
@@ -103,10 +103,10 @@ def install(path):  # type: (str) -> None
 
     logger.info('Installing module with the following command:\n%s', cmd)
 
-    _process.check_error(shlex.split(cmd), _errors.InstallModuleError, cwd=path)
+    _process.check_error(shlex.split(cmd), _errors.InstallModuleError, cwd=path, capture_error=capture_error)
 
 
-def run(module_name, args=None, env_vars=None, wait=True):  # type: (str, list, dict, bool) -> Popen
+def run(module_name, args=None, env_vars=None, wait=True, capture_error=False):  # type: (str, list, dict, bool) -> Popen
     """Run Python module as a script.
 
     Search sys.path for the named module and execute its contents as the __main__ module.
@@ -163,10 +163,10 @@ def run(module_name, args=None, env_vars=None, wait=True):  # type: (str, list, 
     _logging.log_script_invocation(cmd, env_vars)
 
     if wait:
-        return _process.check_error(cmd, _errors.ExecuteUserScriptError)
+        return _process.check_error(cmd, _errors.ExecuteUserScriptError, capture_error=capture_error)
 
     else:
-        return _process.create(cmd, _errors.ExecuteUserScriptError)
+        return _process.create(cmd, _errors.ExecuteUserScriptError, capture_error=capture_error)
 
 
 def import_module(uri, name=DEFAULT_MODULE_NAME, cache=None):  # type: (str, str, bool) -> module

--- a/src/sagemaker_containers/_modules.py
+++ b/src/sagemaker_containers/_modules.py
@@ -95,6 +95,8 @@ def install(path, capture_error=False):  # type: (str) -> None
     """Install a Python module in the executing Python environment.
     Args:
         path (str):  Real path location of the Python module.
+        capture_error (bool): Default false. If True, the running process captures the
+            stderr, and appends it to the returned Exception message in case of errors.
     """
     cmd = '%s -m pip install -U . ' % _process.python_executable()
 
@@ -154,6 +156,8 @@ def run(module_name, args=None, env_vars=None, wait=True, capture_error=False): 
         module_name (str): module name in the same format required by python -m <module-name> cli command.
         args (list):  A list of program arguments.
         env_vars (dict): A map containing the environment variables to be written.
+        capture_error (bool): Default false. If True, the running process captures the
+            stderr, and appends it to the returned Exception message in case of errors.
     """
     args = args or []
     env_vars = env_vars or {}
@@ -195,8 +199,8 @@ def import_module(uri, name=DEFAULT_MODULE_NAME, cache=None):  # type: (str, str
         six.reraise(_errors.ImportModuleError, _errors.ImportModuleError(e), sys.exc_info()[2])
 
 
-def run_module(uri, args, env_vars=None, name=DEFAULT_MODULE_NAME, cache=None, wait=True):
-    # type: (str, list, dict, str, bool, bool) -> Popen
+def run_module(uri, args, env_vars=None, name=DEFAULT_MODULE_NAME, cache=None, wait=True, capture_error=False):
+    # type: (str, list, dict, str, bool, bool, bool) -> Popen
     """Download, prepare and executes a compressed tar file from S3 or provided directory as a module.
 
     SageMaker Python SDK saves the user provided scripts as compressed tar files in S3
@@ -222,7 +226,7 @@ def run_module(uri, args, env_vars=None, name=DEFAULT_MODULE_NAME, cache=None, w
 
     _env.write_env_vars(env_vars)
 
-    return run(name, args, env_vars, wait)
+    return run(name, args, env_vars, wait, capture_error)
 
 
 def _warning_cache_deprecation(cache):

--- a/src/sagemaker_containers/_modules.py
+++ b/src/sagemaker_containers/_modules.py
@@ -91,7 +91,7 @@ def prepare(path, name):  # type: (str, str) -> None
         _files.write_file(os.path.join(path, 'MANIFEST.in'), data)
 
 
-def install(path, capture_error=False):  # type: (str) -> None
+def install(path, capture_error=False):  # type: (str, bool) -> None
     """Install a Python module in the executing Python environment.
     Args:
         path (str):  Real path location of the Python module.

--- a/src/sagemaker_containers/entry_point.py
+++ b/src/sagemaker_containers/entry_point.py
@@ -91,7 +91,7 @@ def install(name, dst):
         os.chmod(os.path.join(dst, name), 511)
 
 
-def _call(user_entry_point, args=None, env_vars=None, wait=True):  # type: (str, list, dict, bool) -> Popen
+def _call(user_entry_point, args=None, env_vars=None, wait=True, capture_error=False):  # type: (str, list, dict, bool) -> Popen
     args = args or []
     env_vars = env_vars or {}
 
@@ -107,10 +107,10 @@ def _call(user_entry_point, args=None, env_vars=None, wait=True):  # type: (str,
     _logging.log_script_invocation(cmd, env_vars)
 
     if wait:
-        return _process.check_error(cmd, _errors.ExecuteUserScriptError)
+        return _process.check_error(cmd, _errors.ExecuteUserScriptError, capture_error=capture_error)
 
     else:
-        return _process.create(cmd, _errors.ExecuteUserScriptError)
+        return _process.create(cmd, _errors.ExecuteUserScriptError, capture_error=capture_error)
 
 
 class EntryPointType(enum.Enum):

--- a/src/sagemaker_containers/entry_point.py
+++ b/src/sagemaker_containers/entry_point.py
@@ -19,8 +19,8 @@ import sys
 from sagemaker_containers import _env, _errors, _files, _logging, _modules, _process
 
 
-def run(uri, user_entry_point, args, env_vars=None, wait=True):
-    # type: (str, str, list, dict, bool) -> subprocess.Popen
+def run(uri, user_entry_point, args, env_vars=None, wait=True, capture_error=False):
+    # type: (str, str, list, dict, bool, bool) -> subprocess.Popen
     """Download, prepare and executes a compressed tar file from S3 or provided directory as an user
     entrypoint. Runs the user entry point, passing env_vars as environment variables and args as command
     arguments.
@@ -59,20 +59,23 @@ def run(uri, user_entry_point, args, env_vars=None, wait=True):
         uri (str): the location of the module.
         wait (bool): If True, holds the process executing the user entry-point.
                      If False, returns the process that is executing it.
+        capture_error (bool): Default false. If True, the running process captures the
+            stderr, and appends it to the returned Exception message in case of errors.
+
      """
     env_vars = env_vars or {}
     env_vars = env_vars.copy()
 
     _files.download_and_extract(uri, user_entry_point, _env.code_dir)
 
-    install(user_entry_point, _env.code_dir)
+    install(user_entry_point, _env.code_dir, capture_error)
 
     _env.write_env_vars(env_vars)
 
-    return _call(user_entry_point, args, env_vars, wait)
+    return _call(user_entry_point, args, env_vars, wait, capture_error)
 
 
-def install(name, dst):
+def install(name, dst, capture_error=False):
     """Install the user provided entry point to be executed as follow:
         - add the path to sys path
         - if the user entry point is a command, gives exec permissions to the script
@@ -80,18 +83,21 @@ def install(name, dst):
     Args:
         name (str): name of the script or module.
         dst (str): path to directory with the script or module.
+        capture_error (bool): Default false. If True, the running process captures the
+            stderr, and appends it to the returned Exception message in case of errors.
     """
     if dst not in sys.path:
         sys.path.insert(0, dst)
 
     entrypoint_type = entry_point_type(dst, name)
     if entrypoint_type is EntryPointType.PYTHON_PACKAGE:
-        _modules.install(dst)
+        _modules.install(dst, capture_error)
     if entrypoint_type is EntryPointType.COMMAND:
         os.chmod(os.path.join(dst, name), 511)
 
 
-def _call(user_entry_point, args=None, env_vars=None, wait=True, capture_error=False):  # type: (str, list, dict, bool) -> Popen
+def _call(user_entry_point, args=None, env_vars=None, wait=True, capture_error=False):
+    # type: (str, list, dict, bool, bool) -> Popen
     args = args or []
     env_vars = env_vars or {}
 

--- a/test/functional/test_download_and_import.py
+++ b/test/functional/test_download_and_import.py
@@ -39,26 +39,35 @@ def erase_user_module():
         pass
 
 
-def test_import_module(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE).upload()
+@pytest.mark.parametrize('user_module',
+                         [test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE),
+                          test.UserModule(USER_SCRIPT_FILE)])
+def test_import_module(user_module, user_module_name):
+    user_module.upload()
 
     module = modules.import_module(user_module.url, user_module_name)
 
     assert module.validate()
 
 
-def test_import_module_with_s3_script(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE).upload()
+@pytest.mark.parametrize('user_module',
+                         [test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE),
+                          test.UserModule(USER_SCRIPT_FILE)])
+def test_import_module_with_s3_script(user_module, user_module_name):
+    user_module.upload()
 
     module = modules.import_module(user_module.url, user_module_name, cache=False)
 
     assert module.validate()
 
 
-def test_import_module_with_local_script(user_module_name, tmpdir):
+@pytest.mark.parametrize('user_module',
+                         [test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE),
+                          test.UserModule(USER_SCRIPT_FILE)])
+def test_import_module_with_local_script(user_module, user_module_name, tmpdir):
     tmp_code_dir = str(tmpdir)
 
-    test.UserModule(USER_SCRIPT_FILE).add_file(SETUP_FILE).create_tmp_dir_with_files(tmp_code_dir)
+    user_module.create_tmp_dir_with_files(tmp_code_dir)
 
     module = modules.import_module(tmp_code_dir, user_module_name, cache=False)
 
@@ -78,8 +87,10 @@ USER_SCRIPT_WITH_REQUIREMENTS = test.File('my_test_script.py', data)
 REQUIREMENTS_FILE = test.File('requirements.txt', 'pyfiglet')
 
 
-def test_import_module_with_s3_script_with_requirements(user_module_name):
-    user_module = test.UserModule(USER_SCRIPT_WITH_REQUIREMENTS).add_file(SETUP_FILE)
+@pytest.mark.parametrize('user_module',
+                         [test.UserModule(USER_SCRIPT_WITH_REQUIREMENTS).add_file(SETUP_FILE),
+                          test.UserModule(USER_SCRIPT_WITH_REQUIREMENTS)])
+def test_import_module_with_s3_script_with_requirements(user_module, user_module_name):
     user_module = user_module.add_file(REQUIREMENTS_FILE).upload()
 
     module = modules.import_module(user_module.url, user_module_name, cache=False)

--- a/test/unit/test_errors.py
+++ b/test/unit/test_errors.py
@@ -25,3 +25,19 @@ def test_execute_user_script_error():
     error = _errors.ExecuteUserScriptError(['python', '-m', '42'], return_code=42)
 
     assert str(error) == 'ExecuteUserScriptError:\nCommand "[\'python\', \'-m\', \'42\']"'
+
+
+def test_install_module_error_with_output():
+    error = _errors.InstallModuleError(['python', '-m', '42'], return_code=42, output=b'42')
+
+    assert str(error) == """InstallModuleError:
+Command "['python', '-m', '42']"
+42"""
+
+
+def test_execute_user_script_error_with_output():
+    error = _errors.ExecuteUserScriptError(['python', '-m', '42'], return_code=42, output=b'42')
+
+    assert str(error) == """ExecuteUserScriptError:
+Command "['python', '-m', '42']"
+42"""

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -51,12 +51,14 @@ def test_install(check_error):
     _modules.install(path)
 
     cmd = [sys.executable, '-m', 'pip', 'install', '-U', '.']
-    check_error.assert_called_with(cmd, _errors.InstallModuleError, cwd=path)
+    check_error.assert_called_with(cmd, _errors.InstallModuleError, cwd=path, capture_error=False)
 
     with patch('os.path.exists', return_value=True):
         _modules.install(path)
 
-        check_error.assert_called_with(cmd + ['-r', 'requirements.txt'], _errors.InstallModuleError, cwd=path)
+        check_error.assert_called_with(
+            cmd + ['-r', 'requirements.txt'], _errors.InstallModuleError,
+            capture_error=False, cwd=path)
 
 
 @patch('sagemaker_containers._process.check_error', autospec=True)
@@ -148,18 +150,20 @@ def test_run(log_script_invocation,  check_error, executable):
 
     expected_cmd = [executable(), '-m', 'pytest', '--version']
     log_script_invocation.assert_called_with(expected_cmd, {})
-    check_error.assert_called_with(expected_cmd, _errors.ExecuteUserScriptError)
+    check_error.assert_called_with(expected_cmd, _errors.ExecuteUserScriptError,
+                                   capture_error=False)
 
 
 @patch('sagemaker_containers._process.python_executable')
 @patch('sagemaker_containers._process.create')
 @patch('sagemaker_containers._logging.log_script_invocation')
 def test_run_no_wait(log_script_invocation,  create, executable):
-    _modules.run('pytest', ['--version'], {'PYPATH': '/opt/ml/code'}, wait=False)
+    _modules.run('pytest', ['--version'], {'PYPATH': '/opt/ml/code'}, wait=False, capture_error=True)
 
     expected_cmd = [executable(), '-m', 'pytest', '--version']
     log_script_invocation.assert_called_with(expected_cmd, {'PYPATH': '/opt/ml/code'})
-    create.assert_called_with(expected_cmd, _errors.ExecuteUserScriptError)
+    create.assert_called_with(expected_cmd, _errors.ExecuteUserScriptError,
+                              capture_error=True)
 
 
 @pytest.mark.parametrize('wait, cache', [[True, False], [True, False]])
@@ -176,7 +180,7 @@ def test_run_module_wait(download_and_extract, write_env_vars, install, run, wai
         write_env_vars.assert_called_with({})
         install.assert_called_with(_env.code_dir)
 
-        run.assert_called_with('default_user_module_name', ['42'], {}, True)
+        run.assert_called_with('default_user_module_name', ['42'], {}, True, False)
 
 
 @patch('sagemaker_containers._files.download_and_extract')

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -129,12 +129,15 @@ def test_exists(import_module):
 
 
 @patch('sagemaker_containers.training_env', lambda: {})
-def test_run_error():
+@pytest.mark.parametrize('capture_error', [True, False])
+def test_run_error(capture_error):
     with pytest.raises(_errors.ExecuteUserScriptError) as e:
-        _modules.run('wrong module')
+        _modules.run('wrong module', capture_error=capture_error)
 
     message = str(e.value)
     assert 'ExecuteUserScriptError:' in message
+    if capture_error:
+        assert ' No module named wrong module' in message
 
 
 @patch('sagemaker_containers._process.python_executable')


### PR DESCRIPTION
# Description of changes: 

## release: 2.3.4
 * feature: add capture_error flag to process.check_error and process.create and to
all functions that runs process: modules.run, modules,run_module, and entry_point.run

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
