### PR TITLE
Re-introduce public methods that were removed in v2.3.1 and bump version to v2.3.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,15 @@
 CHANGELOG
 =========
 
+2.3.5
+=====
+
+* bug-fix: reintroduce ``_modules.s3_download`` and ``_modules.download_and_install`` for backward compatibility
+
 2.3.4
 =====
 
-* feature: add capture_error flag to process.check_error and process.create and to all functions that runs process: modules.run, modules,run_module, and entry_point.run
+* feature: add capture_error flag to process.check_error and process.create and to all functions that runs process: modules.run, modules.run_module, and entry_point.run
 
 2.3.3
 =====
@@ -20,6 +25,8 @@ CHANGELOG
 2.3.1
 =====
 
+* [breaking change] remove ``_modules.prepare`` and ``_modules.download_and_install``
+* [breaking change] move ``_modules.s3_download`` to ``_files.s3_download``
 * feature: support for Bash commands and Python scripts
 
 2.3.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='sagemaker_containers',
-    version='2.3.4',
+    version='2.3.5',
     description='Open source library for creating containers to run on Amazon SageMaker.',
 
     packages=packages,

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -194,3 +194,16 @@ def test_import_module(reload, import_module, install, download_and_extract):
     download_and_extract.assert_called_with('s3://bucket/my-module', 'default_user_module_name', _env.code_dir)
     install.assert_called_with(_env.code_dir)
     reload.assert_called_with(import_module(_modules.DEFAULT_MODULE_NAME))
+
+
+def test_download_and_install_local_directory():
+    uri = '/opt/ml/code'
+
+    with patch('sagemaker_containers._files.s3_download') as s3_download, \
+            patch('sagemaker_containers._modules.prepare') as prepare, \
+            patch('sagemaker_containers._modules.install') as install:
+        _modules.download_and_install(uri)
+
+        s3_download.assert_not_called()
+        prepare.assert_called_with(uri, 'default_user_module_name')
+        install.assert_called_with(uri)


### PR DESCRIPTION
A few things are happening in this PR:
1. add changelog entries to clearly denote the breaking changes we released in v2.3.1
1. re-add ``_modules.s3_download`` and ``_modules.download_and_install``
1. bump version to v2.3.5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
