### PR TITLE
Fixing rmtree error when uri and path is the same

### DIFF
--- a/src/sagemaker_containers/_files.py
+++ b/src/sagemaker_containers/_files.py
@@ -128,6 +128,8 @@ def download_and_extract(uri, name, path):  # type: (str, str, str) -> None
                     t.extractall(path=path)
 
             elif os.path.isdir(uri):
+                if uri == path:
+                    return
                 if os.path.exists(path):
                     shutil.rmtree(path)
                 shutil.move(uri, path)


### PR DESCRIPTION
*Issue #, if available:*
download_and_extract will fail if the path passed in is '/opt/ml/code'. This is because '/opt/ml/code' is a mounted directory.
Relevant [stacktrace](https://gist.github.com/bearpelican/26433a8f8f37cd993515b4a0448859b6)

*Description of changes:*
Put in the most minimal fix possible - avoid removing tree if (uri == path == '/opt/ml/code').
This case happens as a result of this PR: https://github.com/aws/sagemaker-python-sdk/pull/499

A better fix would be safely handle mounted directories, but that'd be a job for someone with more expertise =)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
