### PR TITLE
Set NGINX_PROXY_READ_TIMEOUT=model_server_timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+2.4.3
+=====
+
+* bug-fix: correctly set NGINX_PROXY_READ_TIMEOUT to match model_sever_timeout.
+
 2.4.2
 =====
 

--- a/etc/nginx.conf.template
+++ b/etc/nginx.conf.template
@@ -28,6 +28,7 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
+      proxy_read_timeout %NGINX_PROXY_READ_TIMEOUT%s;
       proxy_pass http://gunicorn;
     }
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ gethostname = setuptools.Extension('gethostname',
 
 setuptools.setup(
     name='sagemaker_containers',
-    version='2.4.2',
+    version='2.4.3',
     description='Open source library for creating containers to run on Amazon SageMaker.',
 
     packages=packages,

--- a/src/sagemaker_containers/_env.py
+++ b/src/sagemaker_containers/_env.py
@@ -883,7 +883,8 @@ class ServingEnv(_Env):
     def model_server_timeout(self):  # type: () -> int
         """Returns:
             int: Timeout in seconds for the model server. This is passed over to gunicorn, from the docs:
-                Workers silent for more than this many seconds are killed and restarted. Our default value is 60."""
+                Workers silent for more than this many seconds are killed and restarted. Our default value is 60.
+                If ``use_nginx`` is True, then this same value will be used for nginx's proxy_read_timeout."""
         return self._model_server_timeout
 
     @property

--- a/src/sagemaker_containers/_server.py
+++ b/src/sagemaker_containers/_server.py
@@ -35,7 +35,8 @@ def _create_nginx_config(serving_env):
 
     pattern = re.compile(r'%(\w+)%')
     template_values = {
-        'NGINX_HTTP_PORT': serving_env.http_port
+        'NGINX_HTTP_PORT': serving_env.http_port,
+        'NGINX_PROXY_READ_TIMEOUT': str(serving_env.model_server_timeout)
     }
 
     config = pattern.sub(lambda x: template_values[x.group(1)], template)


### PR DESCRIPTION
When using a large value for model_server_timeout and USE_NGINX = true
then we need to make nginx set the same proxy_read_timeout otherwise the
flask application is still taking a long time but nginx will close the
connection resulting in the wrong behavior.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
