### PR TITLE
Fix recursive directory navigation

### DIFF
--- a/src/sagemaker_containers/_intermediate_output.py
+++ b/src/sagemaker_containers/_intermediate_output.py
@@ -97,7 +97,10 @@ def _watch(inotify, watchers, watch_flags, s3_uploader):
                 # for it which should cause any problems because when we copy files to temp dir
                 # we add a unique timestamp up to microseconds.
                 if flag is inotify_simple.flags.ISDIR and inotify_simple.flags.CREATE & event.mask:
-                    for folder, dirs, files in os.walk(os.path.join(intermediate_path, event.name)):
+                    path = os.path.join(intermediate_path,
+                                        *[watchers[wd] for wd in range(1, event.wd + 1)],
+                                        event.name)
+                    for folder, dirs, files in os.walk(path):
                         wd = inotify.add_watch(folder, watch_flags)
                         relative_path = os.path.relpath(folder, intermediate_path)
                         watchers[wd] = relative_path

--- a/src/sagemaker_containers/_intermediate_output.py
+++ b/src/sagemaker_containers/_intermediate_output.py
@@ -97,9 +97,8 @@ def _watch(inotify, watchers, watch_flags, s3_uploader):
                 # for it which should cause any problems because when we copy files to temp dir
                 # we add a unique timestamp up to microseconds.
                 if flag is inotify_simple.flags.ISDIR and inotify_simple.flags.CREATE & event.mask:
-                    path = os.path.join(intermediate_path,
-                                        *[watchers[wd] for wd in range(1, event.wd + 1)],
-                                        event.name)
+                    path = os.path.join(
+                    *[intermediate_path] + [watchers[wd] for wd in range(1, event.wd + 1)] + [event.name])
                     for folder, dirs, files in os.walk(path):
                         wd = inotify.add_watch(folder, watch_flags)
                         relative_path = os.path.relpath(folder, intermediate_path)

--- a/src/sagemaker_containers/_intermediate_output.py
+++ b/src/sagemaker_containers/_intermediate_output.py
@@ -97,8 +97,7 @@ def _watch(inotify, watchers, watch_flags, s3_uploader):
                 # for it which should cause any problems because when we copy files to temp dir
                 # we add a unique timestamp up to microseconds.
                 if flag is inotify_simple.flags.ISDIR and inotify_simple.flags.CREATE & event.mask:
-                    path = os.path.join(
-                    *[intermediate_path] + [watchers[wd] for wd in range(1, event.wd + 1)] + [event.name])
+                    path = os.path.join(intermediate_path, watchers[event.wd], event.name)
                     for folder, dirs, files in os.walk(path):
                         wd = inotify.add_watch(folder, watch_flags)
                         relative_path = os.path.relpath(folder, intermediate_path)

--- a/test/unit/test_intermediate_output.py
+++ b/test/unit/test_intermediate_output.py
@@ -51,12 +51,12 @@ def test_non_write_ignored(process_mock, upload_file, inotify_mock, copy2):
     process = process_mock.return_value
     inotify = inotify_mock.return_value
 
-    inotify.add_watch.return_value = 'wd'
+    inotify.add_watch.return_value = 1
     mask = flags.CREATE
     for flag in flags:
         if flag is not flags.CLOSE_WRITE and flag is not flags.ISDIR:
             mask = mask | flag
-    inotify.read.return_value = [Event('wd', mask, 'cookie', 'file_name')]
+    inotify.read.return_value = [Event(1, mask, 'cookie', 'file_name')]
 
     def watch():
         call = process_mock.call_args
@@ -84,8 +84,8 @@ def test_modification_triggers_upload(process_mock, upload_file, inotify_mock, c
     process = process_mock.return_value
     inotify = inotify_mock.return_value
 
-    inotify.add_watch.return_value = 'wd'
-    inotify.read.return_value = [Event('wd', flags.CLOSE_WRITE, 'cookie', 'file_name')]
+    inotify.add_watch.return_value = 1
+    inotify.read.return_value = [Event(1, flags.CLOSE_WRITE, 'cookie', 'file_name')]
 
     def watch():
         call = process_mock.call_args
@@ -115,8 +115,8 @@ def test_new_folders_are_watched(process_mock, upload_file, inotify_mock, copy2)
 
     new_dir = 'new_dir'
     new_dir_path = os.path.join(_env.output_intermediate_dir, new_dir)
-    inotify.add_watch.return_value = 'wd'
-    inotify.read.return_value = [Event('wd', flags.CREATE | flags.ISDIR, 'cookie', new_dir)]
+    inotify.add_watch.return_value = 1
+    inotify.read.return_value = [Event(1, flags.CREATE | flags.ISDIR, 'cookie', new_dir)]
 
     def watch():
         os.makedirs(new_dir_path)


### PR DESCRIPTION
Since event.name of inotify just returns the folder name if a new folder is created, the directory structure wasn't being walked properly. This change fixes the bug to enable correct traversal of the directory.