### PR TITLE
Freeze numpy version to mitigate numpy.load errors.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ packages.append('sagemaker_containers.etc')
 required_packages = [
     # freeze numpy version because of the python2 bug
     # in 16.0: https://github.com/numpy/numpy/pull/12754
-    'numpy<=15.4', 'boto3', 'six', 'pip', 'flask', 'gunicorn', 'typing',
+    'numpy<=1.15.4', 'boto3', 'six', 'pip', 'flask', 'gunicorn', 'typing',
     'gevent', 'inotify_simple', 'werkzeug', 'paramiko==2.4.2', 'psutil==5.4.8'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ packages = setuptools.find_packages(where='src', exclude=('test',))
 packages.append('sagemaker_containers.etc')
 
 required_packages = [
-    'numpy', 'boto3', 'six', 'pip', 'flask', 'gunicorn', 'typing',
+    # freeze numpy version because of the python2 bug
+    # in 16.0: https://github.com/numpy/numpy/pull/12754
+    'numpy<=15.4', 'boto3', 'six', 'pip', 'flask', 'gunicorn', 'typing',
     'gevent', 'inotify_simple', 'werkzeug', 'paramiko==2.4.2', 'psutil==5.4.8'
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
     teamcity-messages
     awslogs
     sagemaker
-    numpy
+    numpy<=15.4
     flask
     gunicorn
     gevent

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
     teamcity-messages
     awslogs
     sagemaker
-    numpy<=15.4
+    numpy<=1.15.4
     flask
     gunicorn
     gevent


### PR DESCRIPTION
Freeze numpy version to mitigate numpy.load errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
