### PR TITLE
Update travis build to use python3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
 - '2.7'
-- '3.5'
+- '3.6'
 install: pip install tox-travis codecov
 script:
 - tox test/unit


### PR DESCRIPTION
Update travis build to use python3.6.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
