### PR TITLE
Set long_description_content_type in setup and bump version to 2.4.4.post1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,6 @@ CHANGELOG
 
 * Specify ``long_description_content_type`` in setup
 
-
 2.4.4
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 CHANGELOG
 =========
 
+2.4.4.post1
+===========
+
+* Specify ``long_description_content_type`` in setup
+
+
 2.4.4
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ gethostname = setuptools.Extension('gethostname',
 
 setuptools.setup(
     name='sagemaker_containers',
-    version='2.4.4',
+    version='2.4.4.post1',
     description='Open source library for creating containers to run on Amazon SageMaker.',
 
     packages=packages,
@@ -56,6 +56,7 @@ setuptools.setup(
     py_modules=[os.path.splitext(os.path.basename(path))[0] for path in glob('src/*.py')],
     ext_modules=[gethostname],
     long_description=read('README.md'),
+    long_description_content_type='text/markdown',
     author='Amazon Web Services',
     url='https://github.com/aws/sagemaker-containers/',
     license='Apache License 2.0',


### PR DESCRIPTION
*Description of changes:*
The README isn't displaying correctly: https://pypi.org/project/sagemaker-containers/2.4.4

I used [twine](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup) to detect and fix the change -

```bash
# before
$ twine check dist/*                                                            
Checking distribution dist/sagemaker_containers-2.4.4.tar.gz: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Failed                                                                                            
The project's long_description has invalid markup which will not be rendered on PyPI. The following syntax errors were detected:
line 23: Warning: Inline literal start-string without end-string.

# after
$ twine check dist/*                                                                     
Checking distribution dist/sagemaker_containers-2.4.4.tar.gz: Passed
```

had some issues adding twine to our tox setup, so I'll check in with @ChoiByungWook to see what he did with https://github.com/aws/sagemaker-python-sdk/pull/643

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
