### PR TITLE
Add twine check in tox and clean up test dependencies

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,9 @@ phases:
       # run linters
       - tox -e flake8
 
+      # run README check
+      - tox -e twine
+
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
     install_requires=required_packages,
 
     extras_require={
-        'test': ['tox', 'flake8==3.6.0', 'pytest', 'pytest-cov', 'mock', 'sagemaker>=1.16.2']
+        'test': ['tox', 'pytest', 'pytest-cov', 'mock', 'sagemaker>=1.16.2']
     },
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
     install_requires=required_packages,
 
     extras_require={
-        'test': ['tox', 'flake8==3.6.0', 'pytest', 'pytest-cov', 'mock', 'sagemaker==1.16.2']
+        'test': ['tox', 'flake8==3.6.0', 'pytest', 'pytest-cov', 'mock', 'sagemaker>=1.16.2']
     },
 
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py36,flake8
+envlist = py27,py36,flake8,twine
 skip_missing_interpreters = False
 
 [flake8]
@@ -18,7 +18,6 @@ exclude =
     venv/
 max-complexity = 15
 builtins = FileNotFoundError
-
 
 [testenv]
 passenv =
@@ -54,3 +53,14 @@ deps =
     pep8-naming
     flake8-import-order
 commands = flake8
+
+[testenv:twine]
+basepython = python3
+# twine check was added starting in 1.12.0
+# https://github.com/pypa/twine/blob/master/docs/changelog.rst
+deps =
+    twine>=1.12.0
+# https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup
+commands =
+    python setup.py sdist
+    twine check dist/*.tar.gz


### PR DESCRIPTION
*Description of changes:*
follow-up to #174 and based on https://github.com/aws/sagemaker-python-sdk/pull/651

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
