### PR TITLE
set nginx proxy timeout >= gunicorn timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+1.1.3
+=====
+
+* bug-fix: make sure nginx proxy_read_timeout >= gunicorn worker timeout
+
 1.1.2
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ PKG_NAME = 'container_support'
 
 setup(
     name='sagemaker_container_support',
-    version='1.1.2',
+    version='1.1.3',
     description='Open source library for creating containers to run on Amazon SageMaker.',
 
     packages=[PKG_NAME],

--- a/src/container_support/etc/nginx.conf.template
+++ b/src/container_support/etc/nginx.conf.template
@@ -29,6 +29,7 @@ http {
       proxy_set_header Host $http_host;
       proxy_redirect off;
       proxy_pass http://gunicorn;
+      proxy_read_timeout %NGINX_PROXY_READ_TIMEOUT%;
     }
 
     location / {

--- a/src/container_support/serving.py
+++ b/src/container_support/serving.py
@@ -162,9 +162,16 @@ class Server(object):
         template = cs.utils.read_file(nginx_config_template_file)
         pattern = re.compile(r'%(\w+)%')
 
+        # make sure nginx proxy timeout >= gunicorn timeout
+        proxy_read_timeout = 60
+        if int(serving_env.model_server_timeout) > 60:
+            proxy_read_timeout = int(serving_env.model_server_timeout)
+
         template_values = {
-            'NGINX_HTTP_PORT': serving_env.http_port
+            'NGINX_HTTP_PORT': serving_env.http_port,
+            'NGINX_PROXY_READ_TIMEOUT': str(proxy_read_timeout)
         }
+
         config = pattern.sub(lambda x: template_values[x.group(1)], template)
         logger.info('nginx config: \n%s\n', config)
         cs.utils.write_file(nginx_config_file, config)


### PR DESCRIPTION
*Description of changes:*

make sure nginx to gunicorn proxy_read_timeout is at least as long as gunicorn worker timeout, otherwise increasing the gunicorn worker timeout won't actually give more time for requests to complete.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
