### PR TITLE
Use specified args, entry point, and env vars when creating a runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 CHANGELOG
 =========
 
+2.4.5.dev
+=========
+
+* bug-fix: use specified args, entry point, and env vars when creating a runner
+
+
 2.4.4.post2
 ===========
 

--- a/src/sagemaker_containers/_runner.py
+++ b/src/sagemaker_containers/_runner.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import
 
 import enum
+from typing import Dict, List  # noqa ignore=F401 imported but unused
 
 import sagemaker_containers
 from sagemaker_containers import _mpi, _params, _process

--- a/src/sagemaker_containers/_runner.py
+++ b/src/sagemaker_containers/_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License'). You
 # may not use this file except in compliance with the License. A copy of
@@ -27,36 +27,41 @@ ProcessRunnerType = RunnerType.Process
 MPIRunnerType = RunnerType.MPI
 
 
-def get(identifier):  # type: (RunnerType) -> _process.Runner
+def get(identifier, user_entry_point=None, args=None, env_vars=None):
+    # type: (RunnerType, str, List[str], Dict[str]) -> _process.Runner
     if isinstance(identifier, _process.ProcessRunner):
         return identifier
     else:
-        return _get_by_runner_type(identifier)
+        return _get_by_runner_type(identifier, user_entry_point, args, env_vars)
 
 
-def _get_by_runner_type(identifier):
+def _get_by_runner_type(identifier, user_entry_point=None, args=None, env_vars=None):
     env = sagemaker_containers.training_env()
+    user_entry_point = user_entry_point or env.user_entry_point
+    args = args or env.to_cmd_args()
+    env_vars = env_vars or env.to_env_vars()
+
     if identifier is RunnerType.MPI and env.is_master:
         processes_per_host = env.additional_framework_parameters.get(_params.MPI_PROCESSES_PER_HOST,
                                                                      1)
         custom_mpi_options = env.additional_framework_parameters.get(_params.MPI_CUSTOM_OPTIONS, '')
 
-        return _mpi.MasterRunner(env.user_entry_point,
-                                 env.to_cmd_args(),
-                                 env.to_env_vars(),
+        return _mpi.MasterRunner(user_entry_point,
+                                 args,
+                                 env_vars,
                                  env.master_hostname,
                                  env.hosts,
                                  processes_per_host,
                                  custom_mpi_options,
                                  env.network_interface_name)
     elif identifier is RunnerType.MPI:
-        return _mpi.WorkerRunner(env.user_entry_point,
-                                 env.to_cmd_args(),
-                                 env.to_env_vars(),
+        return _mpi.WorkerRunner(user_entry_point,
+                                 args,
+                                 env_vars,
                                  env.master_hostname)
     elif identifier is RunnerType.Process:
-        return _process.ProcessRunner(env.user_entry_point,
-                                      env.to_cmd_args(),
-                                      env.to_env_vars())
+        return _process.ProcessRunner(user_entry_point,
+                                      args,
+                                      env_vars)
     else:
         raise ValueError('Invalid identifier %s' % identifier)

--- a/src/sagemaker_containers/entry_point.py
+++ b/src/sagemaker_containers/entry_point.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License'). You
 # may not use this file except in compliance with the License. A copy of
@@ -76,7 +76,7 @@ def run(uri,
 
     _env.write_env_vars(env_vars)
 
-    return _runner.get(runner).run(wait, capture_error)
+    return _runner.get(runner, user_entry_point, args, env_vars).run(wait, capture_error)
 
 
 def install(name, dst, capture_error=False):


### PR DESCRIPTION
Needed to enable https://github.com/aws/sagemaker-tensorflow-container/pull/181. The options here were to either use the args defined (but not passed along) in `entry_point.run` or expose `env._hyperparameters` in a way that it can be modified. I went with the former because the args were already there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
