### PR TITLE
Explicitly set allow_pickle=True for numpy.load and bump version to 2.4.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 CHANGELOG
 =========
 
-2.4.5.dev
-=========
+2.4.5
+=====
 
 * bug-fix: use specified args, entry point, and env vars when creating a runner
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ gethostname = setuptools.Extension('gethostname',
 
 setuptools.setup(
     name='sagemaker_containers',
-    version='2.4.4.post2',
+    version='2.4.5',
     description='Open source library for creating containers to run on Amazon SageMaker.',
 
     packages=packages,

--- a/src/sagemaker_containers/_encoders.py
+++ b/src/sagemaker_containers/_encoders.py
@@ -47,7 +47,7 @@ def npy_to_numpy(npy_array):  # type: (object) -> np.array
         (np.array): converted numpy array.
     """
     stream = BytesIO(npy_array)
-    return np.load(stream)
+    return np.load(stream, allow_pickle=True)
 
 
 def array_to_json(array_like):  # type: (np.array or Iterable or int or float) -> str

--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -35,11 +35,11 @@ def test_array_to_npy(target):
 
     actual = _encoders.array_to_npy(input_data)
 
-    np.testing.assert_equal(np.load(BytesIO(actual)), np.array(target))
+    np.testing.assert_equal(np.load(BytesIO(actual), allow_pickle=True), np.array(target))
 
     actual = _encoders.array_to_npy(target)
 
-    np.testing.assert_equal(np.load(BytesIO(actual)), np.array(target))
+    np.testing.assert_equal(np.load(BytesIO(actual), allow_pickle=True), np.array(target))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
seems like there was a breaking change with numpy: https://github.com/numpy/numpy/commit/a4df7e51483c78853bb33814073498fb027aa9d4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
