### PR TITLE
change: allow MPI options to be passed through entry_point.run

### DIFF
--- a/src/sagemaker_containers/_mpi.py
+++ b/src/sagemaker_containers/_mpi.py
@@ -88,13 +88,14 @@ class MasterRunner(_process.ProcessRunner):
 
     def __init__(self, user_entry_point, args, env_vars, master_hostname, hosts, process_per_host,
                  custom_mpi_options, network_interface_name, interval=1,
-                 timeout_in_seconds=60 * 60):
+                 timeout_in_seconds=60 * 60, num_processes=None):
 
         super(MasterRunner, self).__init__(user_entry_point, args, env_vars)
 
         self._master_hostname = master_hostname
         self._hosts = hosts
         self._process_per_host = process_per_host
+        self._num_processes = num_processes
         self._custom_mpi_options = custom_mpi_options
         self._network_interface_name = network_interface_name
         self._interval = interval
@@ -119,7 +120,7 @@ class MasterRunner(_process.ProcessRunner):
 
     def _create_command(self):  # type: () -> List[str, Any]
         num_hosts = len(self._hosts)
-        num_processes = self._process_per_host * num_hosts
+        num_processes = self._num_processes or self._process_per_host * num_hosts
 
         # By default, use one process per GPU, or one process per node (if training with CPU).
         if self._process_per_host == 1:

--- a/src/sagemaker_containers/_params.py
+++ b/src/sagemaker_containers/_params.py
@@ -45,6 +45,7 @@ SAGEMAKER_HYPERPARAMETERS = (
     USER_PROGRAM_PARAM, SUBMIT_DIR_PARAM, ENABLE_METRICS_PARAM, REGION_NAME_PARAM,
     LOG_LEVEL_PARAM, JOB_NAME_PARAM, DEFAULT_MODULE_NAME_PARAM,
     TUNING_METRIC_PARAM, S3_OUTPUT_LOCATION_PARAM)  # type: tuple
-MPI_PROCESSES_PER_HOST = "sagemaker_mpi_num_of_processes_per_host"  # type: int
-MPI_CUSTOM_OPTIONS = "sagemaker_mpi_custom_mpi_options"  # type: str
+MPI_PROCESSES_PER_HOST = 'sagemaker_mpi_num_of_processes_per_host'  # type: int
+MPI_NUM_PROCESSES = 'sagemaker_mpi_num_processes'  # type: int
+MPI_CUSTOM_OPTIONS = 'sagemaker_mpi_custom_mpi_options'  # type: str
 SAGEMAKER_NETWORK_INTERFACE_NAME = 'sagemaker_network_interface_name'  # type: str

--- a/src/sagemaker_containers/entry_point.py
+++ b/src/sagemaker_containers/entry_point.py
@@ -59,15 +59,24 @@ def run(uri,
          SAGEMAKER_CHANNELS=training SAGEMAKER_CHANNEL_TRAINING=/opt/ml/input/training \
          SAGEMAKER_MODEL_DIR=/opt/ml/model python -m user_script --batch-size 128 --model_dir /opt/ml/model
 
-     Args:
+    Args:
+        uri (str): the location of the module.
         user_entry_point (str): name of the user provided entry point
         args (list):  A list of program arguments.
-        env_vars (dict): A map containing the environment variables to be written.
-        uri (str): the location of the module.
+        env_vars (dict): A map containing the environment variables to be written (default: None).
+        wait (bool): If the user entry point should be run to completion before this method returns
+            (default: True).
         capture_error (bool): Default false. If True, the running process captures the
             stderr, and appends it to the returned Exception message in case of errors.
+        runner (sagemaker_containers.beta.framework.runner.RunnerType): the type of runner object to
+            be created (default: sagemaker_containers.beta.framework.runner.ProcessRunnerType).
+        extra_opts (dict): Additional options for running the entry point (default: None).
+            Currently, this only applies for MPI.
 
-     """
+    Returns:
+        sagemaker_containers.beta.framework.process.ProcessRunner: the runner object responsible for
+            executing the entry point.
+    """
     env_vars = env_vars or {}
     env_vars = env_vars.copy()
 

--- a/src/sagemaker_containers/entry_point.py
+++ b/src/sagemaker_containers/entry_point.py
@@ -25,8 +25,9 @@ def run(uri,
         env_vars=None,
         wait=True,
         capture_error=False,
-        runner=_runner.ProcessRunnerType):
-    # type: (str, str, List[str], Dict[str, str], bool, bool, _runner.RunnerType) -> None
+        runner=_runner.ProcessRunnerType,
+        extra_opts=None):
+    # type: (str, str, List[str], Dict[str, str], bool, bool, _runner.RunnerType, Dict[str, str]) -> None
     """Download, prepare and executes a compressed tar file from S3 or provided directory as an user
     entrypoint. Runs the user entry point, passing env_vars as environment variables and args as command
     arguments.
@@ -76,7 +77,7 @@ def run(uri,
 
     _env.write_env_vars(env_vars)
 
-    return _runner.get(runner, user_entry_point, args, env_vars).run(wait, capture_error)
+    return _runner.get(runner, user_entry_point, args, env_vars, extra_opts).run(wait, capture_error)
 
 
 def install(name, dst, capture_error=False):

--- a/test/unit/test_entry_point.py
+++ b/test/unit/test_entry_point.py
@@ -115,4 +115,17 @@ def test_run_module_with_env_vars(chmod, download_and_extract, get_runner, sys_p
     entry_point.run(uri='s3://url', user_entry_point=module_name, args=args, env_vars={'FOO': 'BAR'})
 
     expected_env_vars = {'FOO': 'BAR', 'PYTHONPATH': ''}
-    get_runner.assert_called_with(_runner.ProcessRunnerType, module_name, args, expected_env_vars)
+    get_runner.assert_called_with(_runner.ProcessRunnerType, module_name, args, expected_env_vars, None)
+
+
+@patch('sys.path')
+@patch('sagemaker_containers._runner.get')
+@patch('sagemaker_containers._files.download_and_extract')
+@patch('os.chmod')
+def test_run_module_with_extra_opts(chmod, download_and_extract, get_runner, sys_path):
+    module_name = 'default_user_module_name'
+    args = ['--some-arg', '42']
+    extra_opts = {'foo': 'bar'}
+
+    entry_point.run(uri='s3://url', user_entry_point=module_name, args=args, extra_opts=extra_opts)
+    get_runner.assert_called_with(_runner.ProcessRunnerType, module_name, args, {}, extra_opts)

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -21,6 +21,13 @@ USER_SCRIPT = 'script'
 CMD_ARGS = ['--some-arg', 42]
 ENV_VARS = {'FOO': 'BAR'}
 
+NCCL_DEBUG_MPI_OPT = '-X NCCL_DEBUG=WARN'
+MPI_OPTS = {
+    'sagemaker_mpi_num_of_processes_per_host': 2,
+    'sagemaker_mpi_num_processes': 4,
+    'sagemaker_mpi_custom_mpi_options': NCCL_DEBUG_MPI_OPT
+}
+
 
 @pytest.mark.parametrize('runner_class', [_process.ProcessRunner, _mpi.MasterRunner, _mpi.WorkerRunner])
 def test_get_runner_returns_runnner_itself(runner_class):
@@ -71,17 +78,21 @@ def test_get_runner_by_mpi_returns_runnner(training_env):
 
 @patch('sagemaker_containers.training_env')
 def test_get_runner_by_mpi_with_extra_args(training_env):
-    runner = _runner.get(_runner.MPIRunnerType, USER_SCRIPT, CMD_ARGS, ENV_VARS)
+    runner = _runner.get(_runner.MPIRunnerType, USER_SCRIPT, CMD_ARGS, ENV_VARS, MPI_OPTS)
 
     assert isinstance(runner, _mpi.MasterRunner)
 
     assert runner._user_entry_point == USER_SCRIPT
     assert runner._args == CMD_ARGS
     assert runner._env_vars == ENV_VARS
+    assert runner._process_per_host == 2
+    assert runner._num_processes == 4
+    assert runner._custom_mpi_options == NCCL_DEBUG_MPI_OPT
 
     training_env().to_cmd_args.assert_not_called()
     training_env().to_env_vars.assert_not_called()
     training_env().user_entry_point.assert_not_called()
+    training_env().additional_framework_parameters.assert_not_called()
 
     training_env().is_master = False
     runner = _runner.get(_runner.MPIRunnerType, USER_SCRIPT, CMD_ARGS, ENV_VARS)


### PR DESCRIPTION
*Description of changes:*
This is to make it easier to configure certain MPI options without having to rely on the exact parameter names in SageMaker Containers, in case, say, you want to make it backward-compatible with some older images (e.g. the [SageMaker Chainer images](https://github.com/aws/sagemaker-chainer-container))

A couple of random notes:
* I chose to make a more generic argument name (`extra_opts`) in case in the future there are other things we might want to pass along for non-MPI processes, but if that's too vague/too much like `**kwargs`, then I can change it to `mpi_opts`, which was my original name for the new argument.
* I added the configurable number of processes because [Chainer has it](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/chainer/estimator.py#L33)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
