### PR TITLE
change: add test for network isolation mode training

### DIFF
--- a/test/functional/test_training_framework.py
+++ b/test/functional/test_training_framework.py
@@ -242,13 +242,14 @@ def test_training_framework_network_isolation(user_script, capture_error):
         f.write(user_script)
         f.close()
 
-    module = test.UserModule(test.File(name='user_script.py', data="")) # dummy module for hyperparameters
+    module = test.UserModule(test.File(name='user_script.py', data=""))  # dummy module for hyperparameters
 
     submit_dir = env.input_dir + '/data/code'
     hyperparameters = dict(training_data_file='training_data.npz', sagemaker_program='user_script.py',
                            sagemaker_submit_directory=submit_dir, epochs=10, batch_size=64, optimizer='Adam')
 
-    test.prepare(user_module=module, hyperparameters=hyperparameters, channels=[channel_train, channel_code], local=True)
+    test.prepare(user_module=module, hyperparameters=hyperparameters, channels=[channel_train, channel_code],
+                 local=True)
 
     assert execute_an_wrap_exit(framework_training_fn) == trainer.SUCCESS_CODE
 

--- a/test/functional/test_training_framework.py
+++ b/test/functional/test_training_framework.py
@@ -225,6 +225,41 @@ def test_training_framework(user_script, capture_error):
     assert model.optimizer == 'Adam'
 
 
+@pytest.mark.parametrize('user_script, capture_error',
+                         [[USER_SCRIPT_WITH_SAVE, False], [USER_SCRIPT_WITH_SAVE, True]])
+def test_training_framework_network_isolation(user_script, capture_error):
+    with pytest.raises(ImportError):
+        importlib.import_module(modules.DEFAULT_MODULE_NAME)
+
+    channel_train = test.Channel.create(name='training')
+    channel_code = test.Channel.create(name='code')
+
+    features = [1, 2, 3, 4]
+    labels = [0, 1, 0, 1]
+    np.savez(os.path.join(channel_train.path, 'training_data'), features=features, labels=labels)
+
+    with open(os.path.join(channel_code.path, 'user_script.py'), 'w') as f:
+        f.write(user_script)
+        f.close()
+
+    module = test.UserModule(test.File(name='user_script.py', data="")) # dummy module for hyperparameters
+
+    submit_dir = env.input_dir + '/data/code'
+    hyperparameters = dict(training_data_file='training_data.npz', sagemaker_program='user_script.py',
+                           sagemaker_submit_directory=submit_dir, epochs=10, batch_size=64, optimizer='Adam')
+
+    test.prepare(user_module=module, hyperparameters=hyperparameters, channels=[channel_train, channel_code], local=True)
+
+    assert execute_an_wrap_exit(framework_training_fn) == trainer.SUCCESS_CODE
+
+    model_path = os.path.join(env.model_dir, 'saved_model')
+    model = fake_ml_framework.Model.load(model_path)
+
+    assert model.epochs == 10
+    assert model.batch_size == 64
+    assert model.optimizer == 'Adam'
+
+
 @pytest.mark.parametrize('user_script, sagemaker_program', [
     [USER_MODE_SCRIPT, 'user_script.py'],
     [BASH_SCRIPT, 'bash_script']


### PR DESCRIPTION
*Description of changes:*
Network Isolation Test in Training for Frameworks
* new test to check the functionality of network isolation mode
* test allows users to pass in script as an entry point via a code channel
* overrides hyperparameter sagemaker_submit_directory to the code channel location to be able to find the script

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
