### PR TITLE
doc: fix path for training script location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Container, including pushing it to ECR, see the example notebook `tensorflow_bri
 How a script is executed inside the container
 ---------------------------------------------
 
-The training script must be located under the folder ``/opt/ml/model`` and its relative path is defined in the environment variable ``SAGEMAKER_PROGRAM``. The following scripts are supported:
+The training script must be located under the folder ``/opt/ml/code`` and its relative path is defined in the environment variable ``SAGEMAKER_PROGRAM``. The following scripts are supported:
 
 -  **Python scripts**: uses the Python interpreter for any script with
    .py suffix


### PR DESCRIPTION
*Issue #, if available:*
User pointed out a doc discrepancy.

https://github.com/aws/sagemaker-containers/issues/195

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
