### PR TITLE
Added execution-parameters to nginx.conf.template

### DIFF
--- a/etc/nginx.conf.template
+++ b/etc/nginx.conf.template
@@ -24,7 +24,7 @@ http {
 
     keepalive_timeout 3;
 
-    location ~ ^/(ping|invocations) {
+    location ~ ^/(ping|invocations|execution-parameters) {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;


### PR DESCRIPTION
/execution-parameters is an optional override for SageMaker Batch Transform

Docs: https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-batch-code.html#your-algorithms-batch-code-how-containe-serves-requests

*Description of changes:*
Updated nginx.conf.template to forward /execution-parameters to gunicorn workers.

If the worker does not implement execution-parameters, the previous response was:
```
HTTP/1.1 404 Not Found
Server: nginx/1.10.3 (Ubuntu)
Date: Tue, 25 Jun 2019 22:26:16 GMT
Content-Type: application/octet-stream
Content-Length: 2
Connection: keep-alive

{}
```

The current response is:
```
HTTP/1.1 404 NOT FOUND
Server: nginx/1.10.3 (Ubuntu)
Date: Tue, 25 Jun 2019 22:17:17 GMT
Content-Type: text/html
Content-Length: 232
Connection: keep-alive

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>404 Not Found</title>
<h1>Not Found</h1>
<p>The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.</p>
```


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
