### PR TITLE
change: add GPU default for MPI processes per host

### DIFF
--- a/src/sagemaker_containers/_runner.py
+++ b/src/sagemaker_containers/_runner.py
@@ -45,7 +45,9 @@ def _get_by_runner_type(identifier, user_entry_point=None, args=None, env_vars=N
     if identifier is RunnerType.MPI and env.is_master:
         mpi_args = extra_opts or {}
 
-        processes_per_host = _mpi_param_value(mpi_args, env, _params.MPI_PROCESSES_PER_HOST, 1)
+        # Default to single process for CPU
+        default_processes_per_host = env.num_gpus if env.num_gpus > 0 else 1
+        processes_per_host = _mpi_param_value(mpi_args, env, _params.MPI_PROCESSES_PER_HOST, default_processes_per_host)
         num_processes = _mpi_param_value(mpi_args, env, _params.MPI_NUM_PROCESSES)
         custom_mpi_options = _mpi_param_value(mpi_args, env, _params.MPI_CUSTOM_OPTIONS, '')
 

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -62,6 +62,8 @@ def test_get_runner_by_process_with_extra_args(training_env):
 
 @patch('sagemaker_containers.training_env')
 def test_get_runner_by_mpi_returns_runnner(training_env):
+    training_env().num_gpus = 0
+
     runner = _runner.get(_runner.MPIRunnerType)
 
     assert isinstance(runner, _mpi.MasterRunner)
@@ -100,6 +102,8 @@ def test_runnner_with_default_gpu_processes_per_host(training_env):
 
 @patch('sagemaker_containers.training_env')
 def test_get_runner_by_mpi_with_extra_args(training_env):
+    training_env().num_gpus = 0
+
     runner = _runner.get(_runner.MPIRunnerType, USER_SCRIPT, CMD_ARGS, ENV_VARS, MPI_OPTS)
 
     assert isinstance(runner, _mpi.MasterRunner)

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -77,6 +77,28 @@ def test_get_runner_by_mpi_returns_runnner(training_env):
 
 
 @patch('sagemaker_containers.training_env')
+def test_runnner_with_default_cpu_processes_per_host(training_env):
+    training_env().additional_framework_parameters = dict()
+    training_env().num_gpus = 0
+
+    runner = _runner.get(_runner.MPIRunnerType)
+
+    assert isinstance(runner, _mpi.MasterRunner)
+    assert runner._process_per_host == 1
+
+
+@patch('sagemaker_containers.training_env')
+def test_runnner_with_default_gpu_processes_per_host(training_env):
+    training_env().additional_framework_parameters = dict()
+    training_env().num_gpus = 2
+
+    runner = _runner.get(_runner.MPIRunnerType)
+
+    assert isinstance(runner, _mpi.MasterRunner)
+    assert runner._process_per_host == 2
+
+
+@patch('sagemaker_containers.training_env')
 def test_get_runner_by_mpi_with_extra_args(training_env):
     runner = _runner.get(_runner.MPIRunnerType, USER_SCRIPT, CMD_ARGS, ENV_VARS, MPI_OPTS)
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-containers/issues/203

*Description of changes:*
Add GPU default for MPI processes per host parameter. It follow this order:

1. user defined input
2. number of gpus
3. 1 (assumes CPU)

Testing against this notebook: https://github.com/awslabs/amazon-sagemaker-examples/blob/master/sagemaker-python-sdk/tensorflow_script_mode_horovod/tensorflow_script_mode_horovod.ipynb

Contingent on: https://github.com/aws/sagemaker-python-sdk/pull/928

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
