### PR TITLE
doc: fix env var in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -506,9 +506,9 @@ SM_INPUT_CONFIG_DIR
 
 .. code:: shell
 
-   SM_INPUT_DIR=/opt/ml/input/config
+   SM_INPUT_CONFIG_DIR=/opt/ml/input/config
 
-The path of the input directory, e.g. ``/opt/ml/input/config/``. The
+The path of the input configuration directory, e.g. ``/opt/ml/input/config/``. The
 directory where standard SageMaker configuration files are located, e.g.
 ``/opt/ml/input/config/``.
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setuptools.setup(
     install_requires=required_packages,
 
     extras_require={
-        'test': ['tox', 'pytest', 'pytest-cov', 'mock', 'sagemaker>=1.16.2']
+        'test': ['tox==3.13.1', 'pytest==4.4.1', 'pytest-cov', 'mock', 'sagemaker>=1.16.2']
     },
 
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
     {env:IGNORE_COVERAGE:} coverage html --rcfile .coveragerc_{envname}
 
 deps =
-    pytest
+    pytest==4.4.1
     pytest-cov
     pytest-xdist
     mock


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-containers/issues/205

*Description of changes:*
Reader has found some inconsistencies in the readme.

Also pinning pytest and tox versions, as pytest is failing when asserting on exception messages.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
