### PR TITLE
ensure exit code is an int

### DIFF
--- a/src/container_support/training.py
+++ b/src/container_support/training.py
@@ -23,7 +23,7 @@ SUCCESS_CODE = 0
 DEFAULT_FAILURE_CODE = 1
 
 
-def _get_valid_exit_code(exit_code):
+def _get_valid_failure_exit_code(exit_code):
     try:
         valid_exit_code = int(exit_code)
     except ValueError:
@@ -52,8 +52,8 @@ class Trainer(object):
             message = 'uncaught exception during training: {}\n{}\n'.format(e, trc)
             logger.error(message)
             TrainingEnvironment.write_failure_file(message, base_dir)
-            error_number = DEFAULT_FAILURE_CODE if not hasattr(e, 'errno') else e.errno
-            exit_code = _get_valid_exit_code(error_number)
+            error_number = e.errno if hasattr(e, 'errno') else DEFAULT_FAILURE_CODE
+            exit_code = _get_valid_failure_exit_code(error_number)
             raise e
         finally:
             # Since threads in Python cannot be stopped, this is the only way to stop the application

--- a/src/container_support/training.py
+++ b/src/container_support/training.py
@@ -19,12 +19,24 @@ from container_support import TrainingEnvironment
 
 logger = logging.getLogger(__name__)
 
+SUCCESS_CODE = 0
+DEFAULT_FAILURE_CODE = 1
+
+
+def _get_valid_exit_code(exit_code):
+    try:
+        valid_exit_code = int(exit_code)
+    except ValueError:
+        valid_exit_code = DEFAULT_FAILURE_CODE
+
+    return valid_exit_code
+
 
 class Trainer(object):
     @classmethod
     def start(cls):
         base_dir = None
-        exit_code = 0
+        exit_code = SUCCESS_CODE
         cs.configure_logging()
         logger.info("Training starting")
         try:
@@ -40,7 +52,8 @@ class Trainer(object):
             message = 'uncaught exception during training: {}\n{}\n'.format(e, trc)
             logger.error(message)
             TrainingEnvironment.write_failure_file(message, base_dir)
-            exit_code = 1 if not hasattr(e, 'errno') else e.errno
+            error_number = DEFAULT_FAILURE_CODE if not hasattr(e, 'errno') else e.errno
+            exit_code = _get_valid_exit_code(error_number)
             raise e
         finally:
             # Since threads in Python cannot be stopped, this is the only way to stop the application


### PR DESCRIPTION
*Description of changes:*
Ensure that the exit_code provided by the final exception handler provided is a valid int as expected by os._exit.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
