### PR TITLE
change: pin flake and werkzeug versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License'). You
 # may not use this file except in compliance with the License. A copy of
@@ -31,8 +31,8 @@ packages = setuptools.find_packages(where='src', exclude=('test',))
 packages.append('sagemaker_containers.etc')
 
 required_packages = [
-    'numpy', 'boto3', 'six', 'pip', 'flask', 'gunicorn', 'typing', 'retrying==1.3.3',
-    'gevent', 'inotify_simple', 'werkzeug', 'paramiko==2.4.2', 'psutil==5.4.8'
+    'numpy', 'boto3', 'six', 'pip', 'flask==1.1.1', 'gunicorn', 'typing', 'retrying==1.3.3',
+    'gevent', 'inotify_simple', 'werkzeug==0.15.0', 'paramiko==2.4.2', 'psutil==5.4.8'
 ]
 
 # enum is introduced in Python 3.4. Installing enum back port


### PR DESCRIPTION
*Issue:*
discovered from following [this example](https://docs.aws.amazon.com/sagemaker/latest/dg/build-container-to-train-script-get-started.html). Due to [pip's lack of dependency management](https://github.com/pypa/pip/issues/988), if you pip install this repository and there's already an existing installation of werkzeug, it won't get upgraded correctly and there will simply be the error message "flask 1.1.1 has requirement Werkzeug>=0.15, but you'll have werkzeug 0.14.1 which is incompatible."

*Description of changes:*
This change pins flask to 1.1.1 and werkzeug to 0.15.0. Though the dependent framework images have varying dependency versions for training, @mvsusp and I have discussed offline that it should be safer to pin serving dependencies, as there is much less variation among the dependent frameworks in this area. Also, going with pinning rather than defining a lower bound as we work toward maintaining more control over package versions that are installed in our Docker images.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
