### PR TITLE
Use copy when installing user module from local path

### DIFF
--- a/src/sagemaker_containers/_files.py
+++ b/src/sagemaker_containers/_files.py
@@ -131,7 +131,7 @@ def download_and_extract(uri, path):  # type: (str, str) -> None
                     return
                 if os.path.exists(path):
                     shutil.rmtree(path)
-                shutil.move(uri, path)
+                shutil.copy(uri, path)
             elif tarfile.is_tarfile(uri):
                 with tarfile.open(name=uri, mode="r:gz") as t:
                     t.extractall(path=path)

--- a/src/sagemaker_containers/_files.py
+++ b/src/sagemaker_containers/_files.py
@@ -131,7 +131,7 @@ def download_and_extract(uri, path):  # type: (str, str) -> None
                     return
                 if os.path.exists(path):
                     shutil.rmtree(path)
-                shutil.copy(uri, path)
+                shutil.copytree(uri, path)
             elif tarfile.is_tarfile(uri):
                 with tarfile.open(name=uri, mode="r:gz") as t:
                     t.extractall(path=path)

--- a/test/unit/test_files.py
+++ b/test/unit/test_files.py
@@ -121,7 +121,7 @@ def test_write_failure_file():
 @patch("sagemaker_containers._files.s3_download")
 @patch("os.path.isdir", lambda x: True)
 @patch("shutil.rmtree")
-@patch("shutil.copy")
+@patch("shutil.copytree")
 def test_download_and_extract_source_dir(copy, rmtree, s3_download):
     uri = _env.channel_path("code")
     _files.download_and_extract(uri, _env.code_dir)

--- a/test/unit/test_files.py
+++ b/test/unit/test_files.py
@@ -121,14 +121,14 @@ def test_write_failure_file():
 @patch("sagemaker_containers._files.s3_download")
 @patch("os.path.isdir", lambda x: True)
 @patch("shutil.rmtree")
-@patch("shutil.move")
-def test_download_and_extract_source_dir(move, rmtree, s3_download):
+@patch("shutil.copy")
+def test_download_and_extract_source_dir(copy, rmtree, s3_download):
     uri = _env.channel_path("code")
     _files.download_and_extract(uri, _env.code_dir)
     s3_download.assert_not_called()
 
     rmtree.assert_any_call(_env.code_dir)
-    move.assert_called_with(uri, _env.code_dir)
+    copy.assert_called_with(uri, _env.code_dir)
 
 
 @patch("sagemaker_containers._files.s3_download")


### PR DESCRIPTION
For Network Isolation mode, the container needs to
copy the user module form /opt/ml/model/code to
/opt/ml/model. shutil.move does not work because
files under the /opt/ml/model directory are read-only.

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
