### PR TITLE
Use pandas in csv encoding/decoding for correct quoted string handling.

### DIFF
--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -94,11 +94,19 @@ def test_array_to_json_exception():
         ("42\n6\n9\n", np.array([42, 6, 9])),
         ("42.0\n6.0\n9.0\n", np.array([42.0, 6.0, 9.0])),
         ("42\n6\n9\n", np.array([42, 6, 9])),
+        ('"False,"\n"True."\n"False,"\n', np.array(["False,", "True.", "False,"])),
+        ('aaa\n"b""bb"\nccc\n', np.array(["aaa", 'b"bb', "ccc"])),
+        ('"a\nb"\nc\n', np.array(["a\nb", "c"])),
     ],
 )
 def test_csv_to_numpy(target, expected):
     actual = _encoders.csv_to_numpy(target)
     np.testing.assert_equal(actual, expected)
+
+
+def test_csv_to_numpy_error():
+    with pytest.raises(_errors.ClientError):
+        _encoders.csv_to_numpy("a\n", dtype="float")
 
 
 @pytest.mark.parametrize(
@@ -107,6 +115,9 @@ def test_csv_to_numpy(target, expected):
         ([42, 6, 9], "42\n6\n9\n"),
         ([42.0, 6.0, 9.0], "42.0\n6.0\n9.0\n"),
         (["42", "6", "9"], "42\n6\n9\n"),
+        (["False,", "True.", "False,"], '"False,"\nTrue.\n"False,"\n'),
+        (["aaa", 'b"bb', "ccc"], 'aaa\n"b""bb"\nccc\n'),
+        (["a\nb", "c"], '"a\nb"\nc\n'),
     ],
 )
 def test_array_to_csv(target, expected):


### PR DESCRIPTION
*Description of changes:*
CSV encoding and decoding for inference does not have the correct behavior when handling string fields that embed special characters (i.e. commas, newlines, double quotes). The expected behavior for the text/csv MIME type can be found in [this document](https://tools.ietf.org/html/rfc4180#section-2). I've replaced the numpy logic in `_encoders.csv_to_numpy` and `_encoders.array_to_csv` with the built-in csv library, which is able to properly read and write in this format.

Additional unit tests were added to test handling of these special characters. Tests run with tox and passing, excluding test_mpi.py (skipped), test_gethostname.py (xfailed), and pylint errors on _mapping.py which already occur before this change.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
