### PR TITLE
feature: adding support for execution_parameters endpoint for serving 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setuptools.setup(
             "pytest==4.4.1",
             "pytest-cov",
             "mock",
-            "sagemaker>=1.16.2",
+            "sagemaker[local]>=1.16.2",
             "black==19.3b0 ; python_version >= '3.6'",
         ]
     },

--- a/src/sagemaker_containers/_worker.py
+++ b/src/sagemaker_containers/_worker.py
@@ -51,7 +51,14 @@ def default_healthcheck_fn():  # type: () -> Response
 class Worker(flask.Flask):
     """Flask application that receives predictions from a Transformer ready for inferences."""
 
-    def __init__(self, transform_fn, initialize_fn=None, module_name=None, healthcheck_fn=None):
+    def __init__(
+        self,
+        transform_fn,
+        initialize_fn=None,
+        module_name=None,
+        healthcheck_fn=None,
+        execution_parameters_fn=None,
+    ):
         """Creates and Flask application from a transformer.
 
         Args:
@@ -71,6 +78,10 @@ class Worker(flask.Flask):
                                                  will use ping as the default healthcheck call.
                                                  Signature:
 
+            execution_parameters_fn (function, optional): function that will be used for responding
+                                                          to execution_parameters calls. If not
+                                                          specified, execution-parameters endpoint
+                                                          will not be supported.
                 * Returns:
                     `flask.app.Response`: response object with new healthcheck response.
 
@@ -93,6 +104,13 @@ class Worker(flask.Flask):
         self.add_url_rule(
             rule="/ping", endpoint="ping", view_func=healthcheck_fn or default_healthcheck_fn
         )
+        if execution_parameters_fn:
+            self.add_url_rule(
+                rule="/execution_parameters",
+                endpoint="execution_parameters",
+                view_func=execution_parameters_fn,
+                methods=["GET"],
+            )
 
         self.request_class = Request
 

--- a/src/sagemaker_containers/_worker.py
+++ b/src/sagemaker_containers/_worker.py
@@ -106,8 +106,10 @@ class Worker(flask.Flask):
         )
         if execution_parameters_fn:
             self.add_url_rule(
-                rule="/execution_parameters", endpoint="execution_parameters",
-                view_func=execution_parameters_fn, methods=["GET"]
+                rule="/execution_parameters",
+                endpoint="execution_parameters",
+                view_func=execution_parameters_fn,
+                methods=["GET"],
             )
 
         self.request_class = Request

--- a/src/sagemaker_containers/_worker.py
+++ b/src/sagemaker_containers/_worker.py
@@ -106,10 +106,8 @@ class Worker(flask.Flask):
         )
         if execution_parameters_fn:
             self.add_url_rule(
-                rule="/execution_parameters",
-                endpoint="execution_parameters",
-                view_func=execution_parameters_fn,
-                methods=["GET"],
+                rule="/execution_parameters", endpoint="execution_parameters",
+                view_func=execution_parameters_fn, methods=["GET"]
             )
 
         self.request_class = Request

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -108,7 +108,7 @@ def test_user_execution_parameters_fn():
     app = _worker.Worker(
         transform_fn=MagicMock(),
         module_name="test_module",
-        execution_parameters_fn=test_execution_parameters_fn,
+        execution_parameters_fn=test_execution_parameters_fn
     )
 
     with app.test_client() as client:

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -108,7 +108,7 @@ def test_user_execution_parameters_fn():
     app = _worker.Worker(
         transform_fn=MagicMock(),
         module_name="test_module",
-        execution_parameters_fn=test_execution_parameters_fn
+        execution_parameters_fn=test_execution_parameters_fn,
     )
 
     with app.test_client() as client:

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     pytest-xdist
     mock
     awslogs
-    sagemaker
+    sagemaker[local]
     numpy
     flask
     gunicorn


### PR DESCRIPTION
This change allows user to specify a method be used for responding
to the execution_parameters endpoint call. If the user does not specify
the function, execution_parameters endpoint will not be available.
`execution_parameters` is an optional endpoint used by SageMaker
Trasnform Job.

For more details:
https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-batch-code.html#your-algorithms-batch-code-how-containe-serves-requests

*Issue #, if available:* NA

*Description of changes:*

This change allows user to specify a method be used for responding
to the execution_parameters endpoint call. If the user does not specify
the function, execution_parameters endpoint will not be available.
`execution_parameters` is an optional endpoint used by SageMaker
Trasnform Job.

For more details:
https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-batch-code.html#your-algorithms-batch-code-how-containe-serves-requests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
