### PR TITLE
bug-fix: Typo in the execution-parameters routing rule

### DIFF
--- a/src/sagemaker_containers/_worker.py
+++ b/src/sagemaker_containers/_worker.py
@@ -106,8 +106,8 @@ class Worker(flask.Flask):
         )
         if execution_parameters_fn:
             self.add_url_rule(
-                rule="/execution_parameters",
-                endpoint="execution_parameters",
+                rule="/execution-parameters",
+                endpoint="execution-parameters",
                 view_func=execution_parameters_fn,
                 methods=["GET"],
             )

--- a/src/sagemaker_containers/_worker.py
+++ b/src/sagemaker_containers/_worker.py
@@ -106,8 +106,10 @@ class Worker(flask.Flask):
         )
         if execution_parameters_fn:
             self.add_url_rule(
-                rule="/execution_parameters", endpoint="execution_parameters",
-                view_func=execution_parameters_fn, methods=["GET"]
+                rule="/execution_parameters",
+                endpoint="execution_parameters",
+                view_func=execution_parameters_fn,
+                methods=["GET"],
             )
 
         self.request_class = Request

--- a/src/sagemaker_containers/_worker.py
+++ b/src/sagemaker_containers/_worker.py
@@ -106,10 +106,8 @@ class Worker(flask.Flask):
         )
         if execution_parameters_fn:
             self.add_url_rule(
-                rule="/execution_parameters",
-                endpoint="execution_parameters",
-                view_func=execution_parameters_fn,
-                methods=["GET"],
+                rule="/execution_parameters", endpoint="execution_parameters",
+                view_func=execution_parameters_fn, methods=["GET"]
             )
 
         self.request_class = Request

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -108,7 +108,7 @@ def test_user_execution_parameters_fn():
     app = _worker.Worker(
         transform_fn=MagicMock(),
         module_name="test_module",
-        execution_parameters_fn=test_execution_parameters_fn,
+        execution_parameters_fn=test_execution_parameters_fn
     )
 
     with app.test_client() as client:

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -108,7 +108,7 @@ def test_user_execution_parameters_fn():
     app = _worker.Worker(
         transform_fn=MagicMock(),
         module_name="test_module",
-        execution_parameters_fn=test_execution_parameters_fn
+        execution_parameters_fn=test_execution_parameters_fn,
     )
 
     with app.test_client() as client:

--- a/test/unit/test_worker.py
+++ b/test/unit/test_worker.py
@@ -96,7 +96,7 @@ def test_response_accept_deprecated():
 def test_no_execution_parameters_fn():
     app = _worker.Worker(transform_fn=MagicMock(), module_name="test_module")
     with app.test_client() as client:
-        response = client.get("/execution_parameters")
+        response = client.get("/execution-parameters")
         assert response.status_code == http_client.NOT_FOUND
 
 
@@ -112,7 +112,7 @@ def test_user_execution_parameters_fn():
     )
 
     with app.test_client() as client:
-        response = client.get("/execution_parameters")
+        response = client.get("/execution-parameters")
         assert response.status_code == http_client.OK
         assert response.get_data().decode("utf-8") == expected_response_string
         assert json.loads(response.get_data().decode("utf-8")) == expected_json


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The endpoint name is execution-paramteres. the previous commit had a typo and was spelled as `execution_parameters`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
