### PR TITLE
fix: pin scipy version >= 1.2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ required_packages = [
     "paramiko==2.4.2",
     "psutil==5.4.8",
     "protobuf>=3.1",
-    "scipy==1.2.2",
+    "scipy>=1.2.2",
 ]
 
 # enum is introduced in Python 3.4. Installing enum back port


### PR DESCRIPTION
*Issue #, if available:*
pin scipy version >=1.2.2 since TensorFlow 2.1.0 requires 1.4.1

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
