### PR TITLE
feature: support specifying S3 endpoint URL

### DIFF
--- a/src/sagemaker_containers/_files.py
+++ b/src/sagemaker_containers/_files.py
@@ -159,6 +159,7 @@ def s3_download(url, dst):  # type: (str, str) -> None
     bucket, key = url.netloc, url.path.lstrip("/")
 
     region = os.environ.get("AWS_REGION", os.environ.get(_params.REGION_NAME_ENV))
-    s3 = boto3.resource("s3", region_name=region)
+    endpoint_url = os.environ.get(_params.S3_ENDPOINT_URL, None)
+    s3 = boto3.resource("s3", region_name=region, endpoint_url=endpoint_url)
 
     s3.Bucket(bucket).download_file(key, dst)

--- a/src/sagemaker_containers/_intermediate_output.py
+++ b/src/sagemaker_containers/_intermediate_output.py
@@ -120,7 +120,9 @@ def _watch(inotify, watchers, watch_flags, s3_uploader):
     executor.shutdown(wait=True)
 
 
-def start_sync(s3_output_location, region):  # pylint: disable=inconsistent-return-statements
+def start_sync(
+    s3_output_location, region, endpoint_url=None
+):  # pylint: disable=inconsistent-return-statements
     """Starts intermediate folder sync which copies files from 'opt/ml/output/intermediate'
     directory to the provided s3 output location as files created or modified.
     If files are deleted it doesn't delete them from s3.
@@ -132,6 +134,7 @@ def start_sync(s3_output_location, region):  # pylint: disable=inconsistent-retu
     Args:
         s3_output_location (str): name of the script or module.
         region (str): the location of the module.
+        endpoint_url (str): an alternative endpoint URL to connect to
 
     Returns:
         (multiprocessing.Process): the intermediate output sync daemonic process.
@@ -154,7 +157,7 @@ def start_sync(s3_output_location, region):  # pylint: disable=inconsistent-retu
         raise ValueError("Expecting 's3' scheme, got: %s in %s" % (url.scheme, url))
 
     # create s3 transfer client
-    client = boto3.client("s3", region)
+    client = boto3.client("s3", region, endpoint_url=endpoint_url)
     s3_transfer = s3transfer.S3Transfer(client)
     s3_uploader = {
         "transfer": s3_transfer,

--- a/src/sagemaker_containers/_intermediate_output.py
+++ b/src/sagemaker_containers/_intermediate_output.py
@@ -141,7 +141,7 @@ def start_sync(
     """
     if not s3_output_location or os.path.exists(intermediate_path):
         logger.debug("Could not initialize intermediate folder sync to s3.")
-        return
+        return None
 
     # create intermediate and intermediate_tmp directories
     os.makedirs(intermediate_path)
@@ -152,7 +152,7 @@ def start_sync(
     url = urlparse(s3_output_location)
     if url.scheme == "file":
         logger.debug("Local directory is used for output. No need to sync any intermediate output.")
-        return
+        return None
     elif url.scheme != "s3":
         raise ValueError("Expecting 's3' scheme, got: %s in %s" % (url.scheme, url))
 

--- a/src/sagemaker_containers/_params.py
+++ b/src/sagemaker_containers/_params.py
@@ -19,6 +19,7 @@ USER_PROGRAM_PARAM = "sagemaker_program"  # type: str
 USER_PROGRAM_ENV = USER_PROGRAM_PARAM.upper()  # type: str
 S3_OUTPUT_LOCATION_PARAM = "sagemaker_s3_output"  # type: str
 S3_OUTPUT_LOCATION_ENV = S3_OUTPUT_LOCATION_PARAM.upper()  # type: str
+S3_ENDPOINT_URL = "S3_ENDPOINT_URL"  # type: str
 TRAINING_JOB_ENV = "TRAINING_JOB_NAME"  # type: str
 SUBMIT_DIR_PARAM = "sagemaker_submit_directory"  # type: str
 SUBMIT_DIR_ENV = SUBMIT_DIR_PARAM.upper()  # type: str

--- a/src/sagemaker_containers/_trainer.py
+++ b/src/sagemaker_containers/_trainer.py
@@ -65,7 +65,10 @@ def train():
         env = sagemaker_containers.training_env()
 
         region = os.environ.get("AWS_REGION", os.environ.get(_params.REGION_NAME_ENV))
-        intermediate_sync = _intermediate_output.start_sync(env.sagemaker_s3_output(), region)
+        s3_endpoint_url = os.environ.get(_params.S3_ENDPOINT_URL, None)
+        intermediate_sync = _intermediate_output.start_sync(
+            env.sagemaker_s3_output(), region, endpoint_url=s3_endpoint_url
+        )
 
         if env.framework_module:
             framework_name, entry_point_name = env.framework_module.split(":")

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -37,7 +37,7 @@ builtins_open = "__builtin__.open" if PY2 else "builtins.open"
 def test_s3_download(resource, url, bucket_name, key, dst, endpoint):
     region = "us-west-2"
     os.environ[_params.REGION_NAME_ENV] = region
-    if endpoint != None:
+    if endpoint is not None:
         os.environ[_params.S3_ENDPOINT_URL] = endpoint
 
     _files.s3_download(url, dst)

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -28,19 +28,25 @@ builtins_open = "__builtin__.open" if PY2 else "builtins.open"
 
 @patch("boto3.resource", autospec=True)
 @pytest.mark.parametrize(
-    "url,bucket_name,key,dst",
+    "url,bucket_name,key,dst,endpoint",
     [
-        ("S3://my-bucket/path/to/my-file", "my-bucket", "path/to/my-file", "/tmp/my-file"),
-        ("s3://my-bucket/my-file", "my-bucket", "my-file", "/tmp/my-file"),
+        ("S3://my-bucket/path/to/my-file", "my-bucket", "path/to/my-file", "/tmp/my-file", None),
+        ("s3://my-bucket/my-file", "my-bucket", "my-file", "/tmp/my-file", "http://localhost:9000"),
     ],
 )
-def test_s3_download(resource, url, bucket_name, key, dst):
+def test_s3_download(resource, url, bucket_name, key, dst, endpoint):
     region = "us-west-2"
     os.environ[_params.REGION_NAME_ENV] = region
+    if endpoint != None:
+        os.environ[_params.S3_ENDPOINT_URL] = endpoint
 
     _files.s3_download(url, dst)
 
-    chain = call("s3", region_name=region).Bucket(bucket_name).download_file(key, dst)
+    chain = (
+        call("s3", region_name=region, endpoint_url=endpoint)
+        .Bucket(bucket_name)
+        .download_file(key, dst)
+    )
     assert resource.mock_calls == chain.call_list()
 
 


### PR DESCRIPTION
#250

This change allows the configuration of the S3 endpoint URL through the environment variable S3_ENDPOINT_URL, which again will allow this container and it's library to be used in local training environments where e.g. minio is used as an S3 replacement.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
