### PR TITLE
fix: Pin protobuf version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ required_packages = [
     "werkzeug==0.15.5",
     "paramiko==2.4.2",
     "psutil==5.4.8",
-    "protobuf>=3.1",
+    "protobuf==3.11.2",
     "scipy>=1.2.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ required_packages = [
     "inotify_simple==1.2.1",
     "werkzeug==0.15.5",
     "paramiko==2.4.2",
-    "psutil==5.4.8",
+    "psutil>=5.6.6",
     "protobuf>=3.1",
     "scipy>=1.2.2",
 ]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ required_packages = [
     "werkzeug==0.15.5",
     "paramiko==2.4.2",
     "psutil==5.4.8",
-    "protobuf==3.11.2",
+    "protobuf==3.1",
     "scipy>=1.2.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ required_packages = [
     "inotify_simple==1.2.1",
     "werkzeug==0.15.5",
     "paramiko==2.4.2",
-    "psutil==5.6.6",
+    "psutil==5.4.8", 
     "protobuf>=3.1",
     "scipy>=1.2.2",
 ]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ required_packages = [
     "werkzeug==0.15.5",
     "paramiko==2.4.2",
     "psutil==5.4.8",
-    "protobuf==3.1",
+    "protobuf==3.11",
     "scipy>=1.2.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ required_packages = [
     "inotify_simple==1.2.1",
     "werkzeug==0.15.5",
     "paramiko==2.4.2",
-    "psutil>=5.6.6",
+    "psutil==5.6.6",
     "protobuf>=3.1",
     "scipy>=1.2.2",
 ]

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ required_packages = [
     "inotify_simple==1.2.1",
     "werkzeug==0.15.5",
     "paramiko==2.4.2",
-    "psutil==5.4.8", 
+    "psutil==5.4.8",
     "protobuf>=3.1",
     "scipy>=1.2.2",
 ]


### PR DESCRIPTION
Fixes an issue with protobuf: `ImportError: No module named google.protobuf`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
