### PR TITLE
fix: extract module to correct location in download_and_install

### DIFF
--- a/src/sagemaker_containers/_modules.py
+++ b/src/sagemaker_containers/_modules.py
@@ -155,10 +155,8 @@ def download_and_install(uri, name=DEFAULT_MODULE_NAME, cache=True):
 
     if not should_use_cache:
         with _files.tmpdir() as tmpdir:
-            dst = os.path.join(tmpdir, "tar_file")
-            _files.download_and_extract(uri, dst)
             module_path = os.path.join(tmpdir, "module_dir")
-            os.makedirs(module_path)
+            _files.download_and_extract(uri, module_path)
             prepare(module_path, name)
             install(module_path)
 

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -218,17 +218,31 @@ def test_import_module(reload, import_module, install, download_and_extract):
     reload.assert_called_with(import_module(_modules.DEFAULT_MODULE_NAME))
 
 
-def test_download_and_install_local_directory():
+@patch("sagemaker_containers._modules.exists", return_value=False)
+@patch("sagemaker_containers._files.tmpdir")
+@patch("sagemaker_containers._files.download_and_extract")
+@patch("sagemaker_containers._modules.prepare")
+@patch("sagemaker_containers._modules.install")
+def test_download_and_install(install, prepare, download_and_extract, files_tmpdir, module_exists):
+    files_tmpdir.return_value.__enter__.return_value = "tmp"
+    uri = "s3://foo/bar"
+    _modules.download_and_install(uri)
+
+    module_path = os.path.join("tmp", "module_dir")
+    download_and_extract.assert_called_with(uri, module_path)
+    prepare.assert_called_with(module_path, "default_user_module_name")
+    install.assert_called_with(module_path)
+
+
+@patch("sagemaker_containers._files.s3_download")
+@patch("tarfile.open")
+@patch("sagemaker_containers._modules.prepare")
+@patch("sagemaker_containers._modules.install")
+def test_download_and_install_local_directory(install, prepare, tarfile, s3_download):
     uri = "/opt/ml/input/data/code/sourcedir.tar.gz"
+    _modules.download_and_install(uri)
 
-    with patch("sagemaker_containers._files.s3_download") as s3_download, patch(
-        "tarfile.open"
-    ) as tarfile, patch("sagemaker_containers._modules.prepare") as prepare, patch(
-        "sagemaker_containers._modules.install"
-    ) as install:
-        _modules.download_and_install(uri)
-
-        s3_download.assert_not_called()
-        tarfile.assert_called_with(name="/opt/ml/input/data/code/sourcedir.tar.gz", mode="r:gz")
-        prepare.assert_called_once()
-        install.assert_called_once()
+    s3_download.assert_not_called()
+    tarfile.assert_called_with(name="/opt/ml/input/data/code/sourcedir.tar.gz", mode="r:gz")
+    prepare.assert_called_once()
+    install.assert_called_once()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/1317#issuecomment-600375775

*Description of changes:*
#246 accidentally changed where the module was getting extracted to because `download_and_extract` combined some of the logic in `s3_download` and `download_and_install`.

*Testing done:*
Unfortunately, I haven't yet figured out why [our functional test](https://github.com/aws/sagemaker-containers/blob/master/test/functional/test_download_and_import.py#L151-L164) does not actually test this behavior.

I did test locally with the MXNet and Scikit-learn images, which were reported as not supporting requirements.txt as a result of this change. What I did was build images, using the prebuilt ones as base images:

```dockerfile
FROM 763104351884.dkr.ecr.us-west-2.amazonaws.com/mxnet-training:1.6.0-cpu-py3

COPY sagemaker_containers-2.8.2.dev0.tar.gz /sagemaker_containers.tar.gz

RUN pip install -U /sagemaker_containers.tar.gz && \
    rm /sagemaker_containers.tar.gz
```

create a simple "training" script:

```python
from pyfiglet import Figlet

print(Figlet().renderText('hello').strip())
```

and requirements.txt:

```
pyfiglet
```

and then run the "training" job locally:

```python
from sagemaker.mxnet import MXNet

mx = MXNet(
    'hello.py',
    source_dir='code',
    role='SageMakerRole',
    py_version='py3',
    train_instance_type='local',
    train_instance_count=1,
    framework_version='1.6.0',
    image_name='test-image:latest',
)

mx.fit()
```

(rinse and repeat using scikit-learn as a base image)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
