### PR TITLE
fix: use shlex.quote to construct bash command

### DIFF
--- a/src/sagemaker_containers/_process.py
+++ b/src/sagemaker_containers/_process.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import io
 import os
+import shlex
 import subprocess
 import sys
 from typing import Dict, List, Mapping  # noqa ignore=F401 imported but unused
@@ -136,7 +137,8 @@ class ProcessRunner(object):
         elif entrypoint_type is _entry_point_type.PYTHON_PROGRAM:
             return self._python_command() + [self._user_entry_point] + self._args
         else:
-            return ["/bin/sh", "-c", "./%s %s" % (self._user_entry_point, " ".join(self._args))]
+            args = [shlex.quote(arg) for arg in self._args]
+            return ["/bin/sh", "-c", "./%s %s" % (self._user_entry_point, " ".join(args))]
 
     def _python_command(self):  # pylint: disable=no-self-use
         """Placeholder docstring"""

--- a/src/sagemaker_containers/_process.py
+++ b/src/sagemaker_containers/_process.py
@@ -136,7 +136,10 @@ class ProcessRunner(object):
         elif entrypoint_type is _entry_point_type.PYTHON_PROGRAM:
             return self._python_command() + [self._user_entry_point] + self._args
         else:
-            args = [six.moves.shlex_quote(arg) for arg in self._args]
+            args = [
+                six.moves.shlex_quote(arg)  # pylint: disable=too-many-function-args
+                for arg in self._args
+            ]
             return ["/bin/sh", "-c", "./%s %s" % (self._user_entry_point, " ".join(args))]
 
     def _python_command(self):  # pylint: disable=no-self-use

--- a/src/sagemaker_containers/_process.py
+++ b/src/sagemaker_containers/_process.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 
 import io
 import os
-import shlex
 import subprocess
 import sys
 from typing import Dict, List, Mapping  # noqa ignore=F401 imported but unused
@@ -137,7 +136,7 @@ class ProcessRunner(object):
         elif entrypoint_type is _entry_point_type.PYTHON_PROGRAM:
             return self._python_command() + [self._user_entry_point] + self._args
         else:
-            args = [shlex.quote(arg) for arg in self._args]
+            args = [six.moves.shlex_quote(arg) for arg in self._args]
             return ["/bin/sh", "-c", "./%s %s" % (self._user_entry_point, " ".join(args))]
 
     def _python_command(self):  # pylint: disable=no-self-use

--- a/test/unit/test_process.py
+++ b/test/unit/test_process.py
@@ -64,9 +64,9 @@ def test_check_error(popen):
 @patch("sagemaker_containers._logging.log_script_invocation")
 def test_run_bash(log, popen, entry_point_type_script):
     with pytest.raises(_errors.ExecuteUserScriptError):
-        _process.ProcessRunner("launcher.sh", ["--lr", "13"], {}).run()
+        _process.ProcessRunner("launcher.sh", ["--lr", "1 3"], {}).run()
 
-    cmd = ["/bin/sh", "-c", "./launcher.sh --lr 13"]
+    cmd = ["/bin/sh", "-c", "./launcher.sh --lr '1 3'"]
     popen.assert_called_with(cmd, cwd=_env.code_dir, env=os.environ, stdout=None, stderr=None)
     log.assert_called_with(cmd, {})
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-containers/issues/263

*Description of changes:*
`shlex.quote` should handle quoting the args so that they are usable for a shell command, even if there are special characters in the args.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
