### PR TITLE
doc: Add package deprecation warning to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-
-.. _header-n1174:
-
 WARNING: This package has been deprecated. Please use the `SageMaker Training Toolkit <https://github.com/aws/sagemaker-training-toolkit>`__ for model training and the `SageMaker Inference Toolkit <https://github.com/aws/sagemaker-inference-toolkit>`__ for model serving.
 ================================================================================================================================================================================================================================================================================
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+
+.. _header-n1174:
+
+WARNING: This package has been deprecated. Please use the `SageMaker Training Toolkit <https://github.com/aws/sagemaker-training-toolkit>`__ for model training and the `SageMaker Inference Toolkit <https://github.com/aws/sagemaker-inference-toolkit>`__ for model serving.
+===============
+
 .. _header-n957:
 
 SageMaker Containers

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 .. _header-n1174:
 
 WARNING: This package has been deprecated. Please use the `SageMaker Training Toolkit <https://github.com/aws/sagemaker-training-toolkit>`__ for model training and the `SageMaker Inference Toolkit <https://github.com/aws/sagemaker-inference-toolkit>`__ for model serving.
-===============
+================================================================================================================================================================================================================================================================================
 
 .. _header-n957:
 


### PR DESCRIPTION
*Description of changes:*
- `sagemaker-containers` is being deprecated in favor of https://github.com/aws/sagemaker-training-toolkit and https://github.com/aws/sagemaker-inference-toolkit
- This change adds a warning to the README redirecting users to the new packages.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-containers/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-containers/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
